### PR TITLE
Refactor link styles

### DIFF
--- a/assets/components/atoms/link/link.scss
+++ b/assets/components/atoms/link/link.scss
@@ -1,60 +1,38 @@
 @charset 'utf-8';
 
-a,
-a:hover,
-a:active { text-decoration: none; }
-
-a:not([class*="btn"]):not([class*="teaser"]):not([class*="card"]):not(.social-icon):not([aria-describedby*="footnote"]):not([aria-describedby*="sidenote"]):not(.no-text-link):not(.news) {
-  position: relative;
-  border-radius: 1px;
+// All links are underlined by default. Supported browsers will have the right color. https://caniuse.com/#feat=text-decoration
+a {
+  text-decoration-color: $link-hover-color;
   transition:
-    color 0.15s ease-in-out,
-    box-shadow 0.15s;
+    text-decoration-color 0.2s ease-in-out,
+    color 0.2s ease-in-out;
 
-  @include pretty-link($epflred, transparent, false, 1px);
-
-  @extend .focused;
-
-  .bg-dark & { color: $white; }
-
-  &:hover,
-  &.hover {
-    text-decoration: none;
-    color: $red;
-
-    @include pretty-link($gray-700, transparent, false, 1px);
-
-    .bg-dark & {
-      color: $white;
-
-      @include pretty-link($gray-300, transparent, false, 1px);
-    }
+  @include hover-focus-active {
+    text-decoration-color: $link-color;
   }
 
-  &:visited,
-  &.visited {
-    text-decoration: none;
-    border-bottom-color: $red;
-  }
-
-  &:focus,
-  &.focus {
-    color: $black;
-
-    .bg-dark & { color: $white; }
-  }
-
-  &:active,
-  &.active {
+  &:active {
     color: $wild-watermelon;
-    border-bottom-color: $red !important;
-    &:before { content: none; }
-    .bg-dark & { color: $wild-watermelon; }
   }
 
   &.text-muted:hover {
-    color: $red !important;
+    color: $link-hover-color !important;
   }
+}
+
+// Manage all the underline colors based on `text-` helper class.
+@each $color, $value in $theme-colors {
+  @include text-emphasis-variant-decoration(".text-#{$color}", $value);
+}
+
+// Special case for white links.
+@include text-emphasis-variant-decoration(".text-white", $white);
+
+// The link pretty allows you to have more cross-browser friendly link styles and the fancy focus box.
+.link-pretty {
+  @include link-pretty($epflred, $body-bg);
+
+  @extend .focused;
 }
 
 .no-text-link {

--- a/assets/components/atoms/link/link.twig
+++ b/assets/components/atoms/link/link.twig
@@ -1,1 +1,4 @@
-<a href="http://bit.ly/2DLIPLo">Teaching & PhD</a>
+<p>Vanilla link: <a href="http://bit.ly/2DLIPLo">Teaching & PhD</a></p>
+<p>Pretty link: <a class="link-pretty" href="http://bit.ly/2DLIPLo">Teaching & PhD</a></p>
+<p class="mt-4">Dark link: <span class="p-3 bg-dark"><a class="text-white" href="http://bit.ly/2DLIPLo">Teaching & PhD</a></span></p>
+<p class="mt-4">Dark pretty link:<span class="p-3 bg-dark"><a class="link-pretty" href="http://bit.ly/2DLIPLo">Teaching & PhD</a></span></p>

--- a/assets/components/atoms/link/link.yml
+++ b/assets/components/atoms/link/link.yml
@@ -1,2 +1,6 @@
 title: Link
 name: link
+notes: |
+  A link is styled by default with a red underline (on [supported browsers](https://caniuse.com/#feat=text-decoration), otherwise, the underline uses the text color).
+
+  A `link-pretty` class can be used to create a better and more cross-browser style.

--- a/assets/components/molecules/card/card.scss
+++ b/assets/components/molecules/card/card.scss
@@ -2,6 +2,7 @@
 
 a.card {
   border: none;
+  text-decoration: none;
 
   .card-body {
     background: $white;
@@ -56,10 +57,10 @@ a.card-img-top {
 
 a.card-title {
   transition: color 0.3s;
-  @include pretty-link($epflred, $white, false, 1px);
+  @include link-pretty($epflred, $white);
   background-position: 0 90% !important;
 
   &:hover {
-    @include pretty-link($black, $white, false, 1px);
+    @include link-pretty($black, $white);
   }
 }

--- a/assets/components/organisms/breadcrumbs/breadcrumbs.scss
+++ b/assets/components/organisms/breadcrumbs/breadcrumbs.scss
@@ -1,50 +1,49 @@
 @charset 'utf-8';
 
-.breadcrumb {
-  .breadcrumb-item {
-    display: inline-block;
-    position: relative;
-    font-size: 0.82rem;
-    line-height: 1.5rem;
+.breadcrumb-item {
+  display: inline-block;
+  position: relative;
+  font-size: 0.82rem;
+  line-height: 1.5rem;
 
-    &:before {
-      content: ' ';
-      display: block;
-      position: absolute;
-      bottom: -0.1rem;
-      left: 0;
-      width: 0;
-      height: 1px;
-      padding: 0;
-      background: $red;
-      transition: width 0.3s ease;
+  &:before {
+    content: ' ';
+    display: block;
+    position: absolute;
+    bottom: -0.1rem;
+    left: 0;
+    width: 0;
+    height: 1px;
+    padding: 0;
+    background: $red;
+    transition: width 0.3s ease;
+  }
+
+  &:not(.active):hover:before {
+    width: calc(100% - 0.6rem);
+  }
+
+  &:after {
+    content: '\203A';
+    padding-left: 0.3rem;
+    color: $gray-400;
+  }
+
+  a {
+    background-image: none !important;
+    color: $gray-600;
+    text-decoration: none;
+
+    &:hover {
+      color: $black;
     }
+  }
 
-    &:not(.active):hover:before {
-      width: calc(100% - 0.6rem);
-    }
+  &:last-child:after {
+    content: none;
+  }
 
-    &:after {
-      content: '\203A';
-      padding-left: 0.3rem;
-      color: $gray-400;
-    }
-
-    a {
-      background-image: none !important;
-      color: $gray-600;
-
-      &:hover {
-        color: $black;
-      }
-    }
-
-    &:last-child:after {
-      content: none;
-    }
-
-    &.active {
-      color: $gray-400;
-    }
+  &.active {
+    color: $gray-400;
   }
 }

--- a/assets/components/organisms/button/button.scss
+++ b/assets/components/organisms/button/button.scss
@@ -1,6 +1,7 @@
 @charset 'utf-8';
 
 .btn {
+  text-decoration: none;
   transition:
     background 0.15s,
     color 0.15s,

--- a/assets/components/organisms/footer/footer.scss
+++ b/assets/components/organisms/footer/footer.scss
@@ -91,13 +91,16 @@
 
   a {
     display: inline-block;
-    background-image: none !important;
     font-size: 0.85rem;
     line-height: 1.2rem;
     color: $gray-600;
-    border-bottom: 1px solid transparent;
+    text-decoration: none;
 
     @extend .text-small;
+
+    &:hover {
+      color: $link-hover-color;
+    }
   }
 
   li {

--- a/assets/components/organisms/link/link-teaser.twig
+++ b/assets/components/organisms/link/link-teaser.twig
@@ -1,13 +1,13 @@
 <div class="links-block links-block-teaser">
-  <h5 id="links-block-title"><a href="#">Vue d’ensemble de l’EPFL</a></h5>
+  <h5 id="links-block-title"><a class="link-pretty" href="#">Vue d’ensemble de l’EPFL</a></h5>
   <nav
     class="nav flex-column flex-wrap align-items-start"
     role="navigation"
     aria-labelledby="links-block-title"
   >
-    <a class="nav-link" href="#">Chiffres clés</a>
-    <a class="nav-link" href="#">3 missions de l’EPFL</a>
-    <a class="nav-link" href="#">Organigrammes de la direction</a>
-    <a class="nav-link" href="#">Réalisations importantes de l’EPFL</a>
+    <a class="nav-link link-pretty" href="#">Chiffres clés</a>
+    <a class="nav-link link-pretty" href="#">3 missions de l’EPFL</a>
+    <a class="nav-link link-pretty" href="#">Organigrammes de la direction</a>
+    <a class="nav-link link-pretty" href="#">Réalisations importantes de l’EPFL</a>
   </nav>
 </div>

--- a/assets/components/organisms/link/link.twig
+++ b/assets/components/organisms/link/link.twig
@@ -5,11 +5,11 @@
     role="navigation"
     aria-labelledby="links-block-title"
   >
-    <a class="nav-link" href="#">Tous les laboratoires de la faculté</a>
-    <a class="nav-link" href="#">Liste des professeurs de la faculté</a>
-    <a class="nav-link" href="#">Postes à pourvoir à l'ENAC</a>
-    <a class="nav-link" href="#">Services internes</a>
-    <a class="nav-link" href="#">L'organisation de la faculté</a>
-    <a class="nav-link" href="#">Chaires de l'ENAC</a>
+    <a class="nav-link link-pretty" href="#">Tous les laboratoires de la faculté</a>
+    <a class="nav-link link-pretty" href="#">Liste des professeurs de la faculté</a>
+    <a class="nav-link link-pretty" href="#">Postes à pourvoir à l'ENAC</a>
+    <a class="nav-link link-pretty" href="#">Services internes</a>
+    <a class="nav-link link-pretty" href="#">L'organisation de la faculté</a>
+    <a class="nav-link link-pretty" href="#">Chaires de l'ENAC</a>
   </nav>
 </div>

--- a/assets/components/organisms/publication/publication.twig
+++ b/assets/components/organisms/publication/publication.twig
@@ -4,7 +4,7 @@
     <p class="h4">James Larus's Publications</p>
   </div>
 
-  <a href="">Profile</a>
+  <a class="link-pretty" href="">Profile</a>
 </div>
 
 <div class="card card-publication">
@@ -13,14 +13,14 @@
     <p class="card-text">14th USENIX Symposium on Networked Systems Design and Implementation, Boston, Massachusetts, USA, 2017.</p>
     <p class="card-text card-subtitle">Author(s)</p>
     <div class="card-links">
-      <a href="#">M. Kogias</a>
-      <a href="#">C. Kozyrakis</a>
-      <a href="#">E. Bugnion</a>
+      <a class="link-pretty" href="#">M. Kogias</a>
+      <a class="link-pretty" href="#">C. Kozyrakis</a>
+      <a class="link-pretty" href="#">E. Bugnion</a>
     </div>
   </div>
   <div class="card-footer">
     <a href="#" class="btn btn-secondary btn-sm">Go somewhere</a>
-    <a href="#">Full text</a>
-    <a href="#">View at publisher</a>
+    <a class="link-pretty" href="#">Full text</a>
+    <a class="link-pretty" href="#">View at publisher</a>
   </div>
 </div>

--- a/assets/components/organisms/teaser-press-review/teaser-press-review.twig
+++ b/assets/components/organisms/teaser-press-review/teaser-press-review.twig
@@ -16,8 +16,8 @@
         <p>
           Le prototype de joystick imaginé par la start-up de l'EPFL MotionPilot permet de piloter un drone d’une seule main, de manière intuitive, rapporte L'Agefi.
         </p>
-        <a href="#">Détails du communiqué</a><br>
-        <a href="#">Communiqué réservé aux journalistes</a>
+        <a class="link-pretty" href="#">Détails du communiqué</a><br>
+        <a class="link-pretty" href="#">Communiqué réservé aux journalistes</a>
         <small>{% include "@atoms/icon/icon.twig" with { icon: 'icon-lock' } %}</small>
       </div>
     </div>

--- a/assets/config/bootstrap-variables.scss
+++ b/assets/config/bootstrap-variables.scss
@@ -148,9 +148,9 @@ $body-color:                $gray-900 !default;
 //
 // Style anchor elements.
 
-$link-color:                $black !default;
-$link-decoration:           none !default;
-$link-hover-color:          $red !default;
+$link-color:                $body-color !default;
+$link-decoration:           underline !default;
+$link-hover-color:          theme-color('primary') !default;
 $link-hover-decoration:     underline !default;
 
 // Paragraphs

--- a/assets/config/helpers.scss
+++ b/assets/config/helpers.scss
@@ -28,6 +28,12 @@
       border-color: $red;
     }
   }
+
+  &:active {
+    &:before {
+      content: none;
+    }
+  }
 }
 
 .text-small {
@@ -59,7 +65,7 @@ input:focus + label > .trapeze-horizontal {
   }
 }
 
-// vertical 
+// vertical
 
 .trapeze-vertical {
   position: absolute;

--- a/assets/config/mixins.scss
+++ b/assets/config/mixins.scss
@@ -1,7 +1,9 @@
  @charset "utf-8";
 
 // Add a beautiful underline to links
-@mixin pretty-link($line: $red, $bg: $body-bg, $hover: true, $size: 1px) {
+// Set $bg to false to text-decoration tweak completely.
+// Set $hover to false to disable hover completely.
+@mixin link-pretty($line: $link-color, $bg: $body-bg, $hover: gray('700'), $size: 1px) {
   text-decoration: none;
   // Underline via gradient background
   background-image: linear-gradient($line 0%, $line 100%);
@@ -9,7 +11,9 @@
   background-size: $size $size;
   background-position: 0 100%;
 
-  @include pretty-link-text-shadow($bg);
+  @if ($bg) {
+    @include link-pretty-text-shadow($bg);
+  }
 
   // Tweak position + thickness for high res (1.75x and up) displays
   @media (min-resolution: 168dpi) {
@@ -17,25 +21,41 @@
     background-position: 0 100%;
   }
 
-  @if ($hover) {
-    @include hover-focus {
-      color: $link-hover-color;
-      text-decoration: none;
-      background-image: none;
-    }
-  }
-
   // Style selected links (or else text-shadow makes it look crazy ugly)
   // Pseudo selectors must go separately, or they break each other
   &::selection {
-    background-color: rgba(theme-color("secondary"), 0.6);
+    background-color: rgba(theme-color('primary'), 0.4);
     color: $body-color;
     text-shadow: none;
+  }
+
+  @if ($hover) {
+    &:hover,
+    &.hover {
+      color: $link-hover-color;
+      text-decoration: none;
+      background-image: linear-gradient($hover 0%, $hover 100%);
+    }
+  }
+
+  // Generate all background variants
+  @each $color, $value in $theme-colors {
+    .bg-#{$color} & {
+      color: color-yiq($value);
+      @include link-pretty-text-shadow($value);
+
+      @if ($hover) {
+        &:hover,
+        &.hover {
+          background-image: linear-gradient(gray('300') 0%, gray('300') 100%);
+        }
+      }
+    }
   }
 }
 
 // Adds the text-shadow to make descendants prettier
-@mixin pretty-link-text-shadow($color) {
+@mixin link-pretty-text-shadow($color) {
   text-shadow:
     3px 0 $color,
     2px 0 $color,
@@ -43,4 +63,12 @@
     -1px 0 $color,
     -2px 0 $color,
     -3px 0 $color;
+}
+
+@mixin text-emphasis-variant-decoration($parent, $color) {
+  a#{$parent} {
+    @include hover-focus {
+      text-decoration-color: $color;
+    }
+  }
 }


### PR DESCRIPTION
We have now a default style for links using text-decoration-color and a `.link-pretty` helper class to use when we need it.

Will close #84 