### PR TITLE
Improve the display of search and language selection for small screen devices

### DIFF
--- a/assets/components/atoms/nav-lang/nav-lang.scss
+++ b/assets/components/atoms/nav-lang/nav-lang.scss
@@ -17,6 +17,11 @@
     font-size: $font-size-sm;
     font-weight: bold;
     transition: background 0.2s ease;
+    
+    @include media-breakpoint-up(sm) {
+      padding-top: ($spacer * 0.6);
+      padding-bottom: ($spacer * 0.7);
+    }
   }
 
   .dropdown-toggle {
@@ -155,26 +160,18 @@
 
 @include media-breakpoint-down(lg) {
   .nav-lang {
-    position: fixed;
-    right: 0;
-    bottom: $mm-lang-height * -1;
-    width: $mm-lang-width;
-    margin: 0;
+    //position: absolute;
+    //right: 120px;
+    //bottom: auto;
+    width: auto;
+    margin: 0 1rem !important;
     transition: bottom 0.3s ease;
     z-index: $zindex-mobile-lang;
-
-    .dropdown-toggle, &.nav-lang-short ul {
-      height: $mm-lang-height;
-      padding-top: 0.67rem;
-      background: gray('600');
-      border-color: gray('600');
-      color: $white;
-      border-radius: 0;
-
-      .icon {
-        color: $white;
-      }
+    
+    &.nav-lang-short {
+      margin: 0 .25rem !important;
     }
+    
     &.nav-lang-short ul{
         display: flex;
         width: 100%;
@@ -188,18 +185,19 @@
           padding: 0;
           a, span{
             display: block;
-            padding: 0;
+            padding: 0 0.4 * $spacer;
             line-height: $mm-lang-height;
             text-align: center;
-            color: gray('300');
+            //color: gray('300');
 
             &.active{
-              color: $white;
+              //color: $white;
             }
           }
           & + li {
             &:before {
-              display: none;
+              //display: none;
+              top: 1.1 * $spacer
             }
           }
         }

--- a/assets/components/atoms/nav-toggle-mobile/nav-toggle-mobile.scss
+++ b/assets/components/atoms/nav-toggle-mobile/nav-toggle-mobile.scss
@@ -4,13 +4,27 @@
   display: flex;
   flex-flow: row nowrap;
   align-items: baseline;
-  margin-left: 1 * $spacer;
-  padding: (0.7 * $spacer) (1.2 * $spacer);
-  font-size: 1.25 * $font-size-base;
+  margin: 0;
+  padding: (.8 * $spacer) (.9 * $spacer);
+  font-size: 1 * $font-size-base;
   font-weight: bold !important;
+    
+  @include media-breakpoint-up(sm) {
+    padding: (.6 * $spacer) (.9 * $spacer);
+  }
+  
+  .label {
+    
+    @include media-breakpoint-down(xs) {
+      @include sr-only();
+    }
+  }
 
   .hamburger {
-    margin-left: 0.4 * $spacer;
+    
+    @include media-breakpoint-up(sm) {
+      margin-left: 0.4 * $spacer;
+    }
 
     span {
       display: block;

--- a/assets/components/atoms/nav-toggle-mobile/nav-toggle-mobile.twig
+++ b/assets/components/atoms/nav-toggle-mobile/nav-toggle-mobile.twig
@@ -1,5 +1,5 @@
 <div class="btn btn-secondary nav-toggle-mobile d-xl-none">
-  Menu
+  <span class="label">Menu</span>
   <div class="hamburger">
     <span></span>
     <span></span>

--- a/assets/components/base.js
+++ b/assets/components/base.js
@@ -15,6 +15,7 @@ import svgIcons from '../icons/svg-icons';
 import nav from './organisms/nav-main/nav-main.js';
 import drawer from './atoms/drawer/drawer.js';
 import search from './molecules/search/search.js';
+import searchMobile from './molecules/search/search-mobile.js';
 import coursebook from './content-types/coursebook/coursebook.js';
 import cookieconsent, {get_cookieconsent_config} from './organisms/cookie-consent/cookie-consent.js';
 import anchors from './anchors';

--- a/assets/components/molecules/search/search-mobile.js
+++ b/assets/components/molecules/search/search-mobile.js
@@ -1,0 +1,31 @@
+/* global $ */
+
+$(document).ready(function($){
+
+  $('html').addClass('redpandas-will-rule-the-world');
+
+  $('#search-mobile-toggle').click(function(event){
+    
+    var searchContainer = $('.search-mobile');
+    var searchField = searchContainer.find('.form-control');
+    
+    searchContainer.toggleClass('show');
+    $('body').toggleClass('search-open');
+    
+    if ( searchContainer.hasClass('show') ) {
+      searchField.focus();
+    }
+    
+  });
+
+  $('#search-mobile-close').click(function(event){
+    
+    var searchContainer = $('.search-mobile');
+    var searchField = searchContainer.find('.form-control');
+    
+    searchContainer.removeClass('show');
+    $('body').removeClass('search-open');
+    
+  });
+  
+});

--- a/assets/components/molecules/search/search-mobile.twig
+++ b/assets/components/molecules/search/search-mobile.twig
@@ -1,11 +1,21 @@
 <form action="#" class="d-xl-none">
+  <a id="search-mobile-toggle" class="search-mobile-toggle searchform-controller" href="#">
+    {% include '@atoms/icon/icon.twig' with { icon: 'icon-search' } %}
+    <span class="toggle-label sr-only">Afficher / masquer le formulaire de recherche</span>
+  </a>
   <div class="input-group search-mobile" role="search">
     <div class="input-group-prepend">
       <span class="input-group-text">
         {% include '@atoms/icon/icon.twig' with { icon: 'icon-search' } %}
       </span>
     </div>
-      <label for="search" class="sr-only">Rechercher sur le site</label>
-      <input type="text" class="form-control" name="search" placeholder="Rechercher">
+    <label for="search" class="sr-only">Rechercher sur le site</label>
+    <input type="text" class="form-control" name="search" placeholder="Rechercher">
+    <div class="input-group-append">
+      <a id="search-mobile-close" class="search-mobile-close searchform-controller" href="#">
+        {% include '@atoms/icon/icon.twig' with { icon: 'icon-close' } %}
+        <span class="toggle-label sr-only">Masquer le formulaire de recherche</span>
+      </a>
+    </div>
   </div>
 </form>

--- a/assets/components/molecules/search/search.scss
+++ b/assets/components/molecules/search/search.scss
@@ -23,16 +23,28 @@
   }
 }
 
+.search-mobile-toggle {
+  
+  .icon {
+    height: 16px;
+    width: 16px;
+  }
+}
+
 .search-mobile {
   display: none;
 
   @include media-breakpoint-down (xl) {
+    background: $black;
     display: flex;
     flex-flow: row nowrap;
-    position: fixed;
-    bottom: -$mm-lang-height;
+    position: absolute;
+    top: -$mm-lang-height;
     left: 0;
-    width: calc(100% - #{ $mm-lang-width });
+    bottom: auto;
+    right: 0;
+    //width: calc(100% - #{ $mm-lang-width });
+    width: 100%;
     height: $mm-lang-height;
     transition: bottom 0.3s;
     z-index: $zindex-mobile-lang - 1;
@@ -59,5 +71,30 @@
     .icon {
       color: gray('300');
     }
+    
+    .searchform-controller .icon {
+      display: block;
+      transition: color .2s ease-in-out;
+    }
+    
+    .search-mobile-close {
+      align-items: center;
+      display: flex;
+      margin: 0 (0.9 * $spacer);
+      
+      &:hover .icon {
+        color: #fff;
+      }
+    }
+  }
+}
+
+.site {
+  position: relative;
+  top: 0;
+  transition: top .3s ease-in-out;
+  
+  .search-open & {
+    top: $mm-lang-height;
   }
 }

--- a/assets/components/organisms/header/header.scss
+++ b/assets/components/organisms/header/header.scss
@@ -4,7 +4,7 @@
   display: flex;
   width: 100%;
   flex-flow: row nowrap;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   height: $header-height;
 
@@ -18,13 +18,16 @@
   }
 
   .logo {
-    margin: 0;
+    margin: 0 auto 0 (3 * $spacer);
     border: none;
     background-image: none;
-    margin-left: 3 * $spacer;
 
     &:before {
       content: none;
+    }
+
+    @include media-breakpoint-up(xl) {
+      margin-right: 0;
     }
   }
 

--- a/assets/components/organisms/nav-main/nav-main.scss
+++ b/assets/components/organisms/nav-main/nav-main.scss
@@ -343,7 +343,7 @@ a.nav-arrow {
     }
 
     .nav-lang {
-      bottom: 0;
+      //bottom: 0;
     }
 
     .nav-lang-mobile {

--- a/assets/components/templates/base/base.twig
+++ b/assets/components/templates/base/base.twig
@@ -1,4 +1,4 @@
-
+<div class="site">
 {% include '@molecules/access-nav/access-nav.twig' %}
 
 {% block fullintro %}{% endblock %}
@@ -50,4 +50,5 @@
   </div>
   {% endblock %}
   </div>
+</div>
 </div>


### PR DESCRIPTION
Afin d'améliorer l'accès au sélecteur de langue et au champ de recherche en version mobile:

- Le sélecteur de langue est déplacé en dehors du menu mobile afin d'être accessible plus facilement.
- Ajout d'une icône "loupe" à côté du sélecteur de langue, qui permet de faire apparaître le champ de recherche au-dessus du header.
- Le comportement du menu mobile demeure inchangé.