### PR TITLE
Add "overflow: hidden" to .hero element

### DIFF
--- a/assets/components/organisms/hero/hero.scss
+++ b/assets/components/organisms/hero/hero.scss
@@ -1,6 +1,8 @@
 @charset 'utf-8';
 
 .hero {
+  overflow: hidden;
+  
   @include media-breakpoint-up(md) {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
Prevents image from overflowing when the title is too long.
https://epfl-webvolution.atlassian.net/browse/WEBEVOL-4