### PR TITLE
Apply min-height property only for screens larger or equal to 768 px

### DIFF
--- a/assets/components/organisms/fullwidth-teaser/fullwidth-teaser.scss
+++ b/assets/components/organisms/fullwidth-teaser/fullwidth-teaser.scss
@@ -3,7 +3,6 @@
 .fullwidth-teaser {
   position: relative;
   width: 100%;
-  min-height: 30rem;
   background: $gray-100;
 
   .vimeo-wrapper {
@@ -13,6 +12,7 @@
   @include media-breakpoint-up(md) {
     display: flex;
     flex-flow: row nowrap;
+    min-height: 30rem;
   }
 
   @include media-breakpoint-up(lg) {


### PR DESCRIPTION
Corrige le problème de la zone grise qui apparait sous le teaser sur les petits écrans (https://epfl-webvolution.atlassian.net/browse/WEBEVOL-7)