### PR TITLE
Fix list stylelint warnings

### DIFF
--- a/assets/components/atoms/list/list.scss
+++ b/assets/components/atoms/list/list.scss
@@ -5,11 +5,11 @@
   margin-left: -0.7rem;
 
   li {
+    $bullet-size: $spacer * 0.8;
+
     list-style-type: none;
     padding-left: $spacer;
     position: relative;
-
-    $bullet-size: $spacer * 0.8;
 
     &:before {
       content: '';
@@ -18,9 +18,9 @@
       right: calc(100% - 0.5rem);
       width: 6px;
       height: 5px;
+      background: $red;
       font-size: 1.1rem;
       line-height: $bullet-size;
-      background: $red;
     }
   }
 


### PR DESCRIPTION
Should fix:

```
../../assets/components/atoms/list/list.scss
12:5	⚠  Expected $-variable to come before declaration (order/order) [stylelint]
23:7	⚠  Expected "background" to come before "line-height" (order/properties-order) [stylelint]
```