### PR TITLE
Fix search stylelint warnings

### DIFF
--- a/assets/components/molecules/search/search.scss
+++ b/assets/components/molecules/search/search.scss
@@ -24,10 +24,10 @@
 }
 
 .search-mobile-toggle {
-  
+
   .icon {
-    height: 16px;
     width: 16px;
+    height: 16px;
   }
 }
 
@@ -35,17 +35,17 @@
   display: none;
 
   @include media-breakpoint-down (xl) {
-    background: $black;
     display: flex;
     flex-flow: row nowrap;
     position: absolute;
     top: -$mm-lang-height;
-    left: 0;
-    bottom: auto;
     right: 0;
+    bottom: auto;
+    left: 0;
     //width: calc(100% - #{ $mm-lang-width });
     width: 100%;
     height: $mm-lang-height;
+    background: $black;
     transition: bottom 0.3s;
     z-index: $zindex-mobile-lang - 1;
 
@@ -71,17 +71,17 @@
     .icon {
       color: gray('300');
     }
-    
+
     .searchform-controller .icon {
       display: block;
       transition: color .2s ease-in-out;
     }
-    
+
     .search-mobile-close {
       align-items: center;
       display: flex;
       margin: 0 (0.9 * $spacer);
-      
+
       &:hover .icon {
         color: #fff;
       }


### PR DESCRIPTION
Should fix:

```
../../assets/components/molecules/search/search.scss
30:5	⚠  Expected "width" to come before "height" (order/properties-order) [stylelint]
39:5	⚠  Expected "display" to come before "background" (order/properties-order) [stylelint]
44:5	⚠  Expected "bottom" to come before "left" (order/properties-order) [stylelint]
45:5	⚠  Expected "right" to come before "bottom" (order/properties-order) [stylelint]
```

