### PR TITLE
Fix multiple select image

### DIFF
--- a/assets/components/atoms/select/select.scss
+++ b/assets/components/atoms/select/select.scss
@@ -51,11 +51,6 @@
     right: 0;
     width: 20px;
     height: 25px;
-    background: url('multiple-select.png') left top no-repeat;
-
-    &.open {
-      background: url('multiple-select.png') right top no-repeat;
-    }
   }
 }
 


### PR DESCRIPTION
I tried to add the image (`node_modules/multiple-select/multiple-select.png`) and I got the following result:

![multi](https://user-images.githubusercontent.com/2843501/60718856-2d5aa680-9f26-11e9-93de-ab8b4d7bc9e9.png)

Since we already have an icon, I propose to delete background styles.
Close #373 

