### PR TITLE
Fix study plan stylelint warnings

### DIFF
--- a/assets/components/content-types/study-plan/study-plan.scss
+++ b/assets/components/content-types/study-plan/study-plan.scss
@@ -1,17 +1,17 @@
 @charset 'utf-8';
 
-.table-like {
-  $table-cours-template-columns: minmax(200px, 3fr) minmax(auto, 1fr) minmax(200px, 3fr);
-  $table-grid-template-columns: 1fr $table-cours-template-columns 2fr 2fr 2fr minmax(200px, 3fr) 1fr;
+$table-cours-template-columns: minmax(200px, 3fr) minmax(auto, 1fr) minmax(200px, 3fr);
+$table-grid-template-columns: 1fr $table-cours-template-columns 2fr 2fr 2fr minmax(200px, 3fr) 1fr;
 
+.table-like {
   --table-columns: #{$table-grid-template-columns};
 
   overflow-x: scroll;
   max-width: 100%;
 
   h4 {
-    font-weight: $font-weight-bold;
     font-size: $font-size-base;
+    font-weight: $font-weight-bold;
   }
 
   // Lines
@@ -42,10 +42,10 @@
   }
 
   .first-line {
-    color: $table-head-color;
-    font-weight: $font-weight-bold;
-    text-transform: uppercase;
     font-size: 0.6875 * $font-size-base;
+    font-weight: $font-weight-bold;
+    color: $table-head-color;
+    text-transform: uppercase;
 
     > div {
       border-top: $table-border-width solid $table-border-color;
@@ -88,7 +88,7 @@
       margin-bottom: 0;
       padding-bottom: $headings-margin-bottom;
     }
-    
+
     .line-down + h3,
     .line-down +  h4 {
       padding-top: 2em;


### PR DESCRIPTION
Should fix:

```
7:3  ⚠  Expected custom property to come before $-variable (order/order) [stylelint]
14:5 ⚠  Expected "font-size" to come before "font-weight" (order/properties-order) [stylelint]
46:5 ⚠  Expected "font-weight" to come before "color" (order/properties-order) [stylelint]
48:5 ⚠  Expected "font-size" to come before "font-weight" (order/properties-order) [stylelint]
```