### PR TITLE
Fix stylelint issue in form group

### DIFF
--- a/assets/components/molecules/form-group/form-group.scss
+++ b/assets/components/molecules/form-group/form-group.scss
@@ -2,10 +2,10 @@
 
 .form-group {
   label {
-    color: $gray-600;
     font-size: 1em;
+    color: $gray-600;
   }
-  
+
   .custom-control label {
     font-size: $font-size-sm;
   }


### PR DESCRIPTION
Should fix:

```
../../assets/components/molecules/form-group/form-group.scss
6:5	⚠ Expected "font-size" to come before "color" (order/properties-order) [stylelint]
```

... from PR #425 

Review was too fast...

From PR #400
> Merci, je check la prochaine que les PR ne casse plus le styleint