### PR TITLE
Move padding from 'table-boxed' class to 'table' class

### DIFF
--- a/assets/components/molecules/tables/tables.scss
+++ b/assets/components/molecules/tables/tables.scss
@@ -6,7 +6,7 @@
   thead {
     th {
       border-bottom: 3px solid $gray-200;
-      padding: 0.3rem 0;
+      padding: 0.3rem 0.45rem;
     }
   }
 
@@ -15,7 +15,7 @@
     color: $black;
 
     td {
-      padding: 0.3rem 0;
+      padding: 0.3rem 0.45rem;
       border-bottom: 1px solid $gray-200;
 
       @include media-breakpoint-down(sm) {
@@ -50,8 +50,6 @@
   thead th,
   tbody td,
   tfoot td {
-    padding-left: 0.45rem;
-    padding-right: 0.45rem;
     border-right: 1px solid $gray-200;
 
     @include media-breakpoint-down(sm) {


### PR DESCRIPTION
Quand on met beaucoup de texte dans un tableau, comme il n'y a pas de padding gauche et droite dans les cellules, ça fait tout moche... 
Du padding est ajouté quand on met la classe `table-boxed` mais celle-ci ajoute aussi des bordures au tableau qui sont quelque peu indésirables. Donc, accord avec Luc pour déplacer le CSS qui met du padding depuis la classe `table-boxed` vers `table`.

En lien avec https://github.com/epfl-idevelop/wp-gutenberg-epfl/pull/164 pour que ça fonctionne.