### PR TITLE
Highlighted news teaser: prevent cover image crop

### DIFF
--- a/assets/components/content-types/news/news-highlighted.twig
+++ b/assets/components/content-types/news/news-highlighted.twig
@@ -1,1 +1,1 @@
-{% include '@organisms/fullwidth-teaser/fullwidth-teaser-horizontal.twig' %}
+{% include '@organisms/fullwidth-teaser/fullwidth-teaser-horizontal.twig' with { news_teaser: true } %}

--- a/assets/components/content-types/news/news.yml
+++ b/assets/components/content-types/news/news.yml
@@ -3,6 +3,8 @@ name: news
 variants:
   - name: highlighted
     title: Highlighted
+    notes:  |
+      Use the class 'fullwidth-teaser-news' only in cases where you want to prevent the cover image from being cropped.
   - name: highlighted-carousel
     title: Highlighted Carousel
   - name: latest-two

--- a/assets/components/organisms/fullwidth-teaser/fullwidth-teaser-horizontal.twig
+++ b/assets/components/organisms/fullwidth-teaser/fullwidth-teaser-horizontal.twig
@@ -1,6 +1,6 @@
 {% set thinner_teaser = thinner_teaser|default(false) %}
 
-<div class="fullwidth-teaser fullwidth-teaser-horizontal{% if thinner_teaser %} thinner-teaser{% endif %}">
+<div class="fullwidth-teaser fullwidth-teaser-horizontal{% if thinner_teaser %} thinner-teaser{% endif %}{% if news_teaser %} fullwidth-teaser-news{% endif %}">
   <picture>
     {% if not img %}{% set img %}./images/styleguide/basic_page_teaser.jpg{% endset %}{% endif %}
     <img src="{{img}}" aria-labelledby="background-label" alt="An image description"/>

--- a/assets/components/organisms/fullwidth-teaser/fullwidth-teaser.scss
+++ b/assets/components/organisms/fullwidth-teaser/fullwidth-teaser.scss
@@ -84,6 +84,15 @@
   }
 }
 
+.fullwidth-teaser-news {
+  
+  picture,
+  figure {
+    height: auto;
+    max-height: none;
+  }
+}
+
 .fullwidth-teaser-text {
   padding: 1rem $grid-gutter-width/2 0;
   background: $white;


### PR DESCRIPTION
Add class 'fullwidth-teaser-news' to prevent cover image from being cropped.
https://epfl-webvolution.atlassian.net/browse/WEBEVOL-107