### PR TITLE
Bugfix: Atoms/Collapse - replaced padding with pseudo-element for smooth transitions

### DIFF
--- a/assets/components/atoms/collapse/collapse.scss
+++ b/assets/components/atoms/collapse/collapse.scss
@@ -86,7 +86,11 @@ $collapse-chevron-size: 12px;
 }
 
 .collapse-item {
-  padding-bottom: 2rem;
+  &::after {
+    content: "";
+    display: block;
+    padding-top: 2rem;
+  }
 
   *:last-child {
     margin-bottom: 0;
@@ -124,7 +128,11 @@ header.collapse-title {
 }
 
 header.collapse-title + .collapse-item {
-  padding-top: 0.5rem;
+  &::before {
+    content: "";
+    display: block;
+    padding-top: 0.5rem;
+  }
 }
 
 .collapse-group {


### PR DESCRIPTION
Padding on element with height transitions results in rough animation. Therefor I propose to replace the padding with pseudo element (content:"") with the same height to maintain the visual style and create smooth transitions.

Before (note the "jump" in the beginning and end of the transition):
https://user-images.githubusercontent.com/3518980/167589701-b58039b6-fbf2-4881-a391-e68faed4d3d2.mov

After:
https://user-images.githubusercontent.com/3518980/167589773-178d69d1-18a1-475f-b400-59e432dfde93.mov


