### PR TITLE
Lighter border color for cards

### DIFF
--- a/assets/components/molecules/card/card.scss
+++ b/assets/components/molecules/card/card.scss
@@ -21,6 +21,8 @@
 }
 
 .card-gray {
+  border-color: $gray-200;
+
   .card-footer,
   .card-body {
     background: $gray-100;

--- a/assets/components/molecules/card/card.scss
+++ b/assets/components/molecules/card/card.scss
@@ -3,6 +3,7 @@
 //
 // Normal card
 .card {
+  border-color: $gray-100;
   border-radius: 0;
   flex: 1 1 0%;
   max-width: 100%;


### PR DESCRIPTION
Utilisation d'une couleur plus claire ($gray-100) pour la bordure des éléments .card.

https://epfl-webvolution.atlassian.net/browse/WEBEVOL-190