### PR TITLE
[depends] `jquery`

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "flickity-fullscreen": "^1.1.1",
     "imagesloaded": "^4.1.4",
     "intro.js": "^2.9.3",
-    "jquery": "^3.6.0",
+    "jquery": "^3",
     "jquery-mousewheel": "^3.1.13",
     "multiple-select": "^1.5.2",
     "object-fit-images": "^3.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5542,10 +5542,15 @@ jquery-ui@^1.13.0:
   dependencies:
     jquery ">=1.8.0 <4.0.0"
 
-jquery@>=1.7, "jquery@>=1.8.0 <4.0.0", jquery@^3.6.0:
+jquery@>=1.7, "jquery@>=1.8.0 <4.0.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+
+jquery@^3:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.1.tgz#fab0408f8b45fc19f956205773b62b292c147a16"
+  integrity sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==
 
 js-beautify@^1.14.0:
   version "1.14.0"


### PR DESCRIPTION
The JavaScript code in elements depends directly on jQuery ([example](https://github.com/epfl-si/elements/blob/dev/assets/components/entrypoint.js)). Therefore, the dependency should be explicit.
