### PR TITLE
Flickity: remove some dead code and style exceptions

### DIFF
--- a/assets/components/molecules/gallery/gallery.js
+++ b/assets/components/molecules/gallery/gallery.js
@@ -1,9 +1,9 @@
 /* globals $ */
 
 import Flickity from 'flickity';
-import FlickityFullscreen from 'flickity-fullscreen'; // eslint-disable-line
-import FlickityNav from 'flickity-as-nav-for'; // eslint-disable-line
-import Imagesloaded from 'imagesloaded';
+import 'flickity-fullscreen';
+import 'flickity-as-nav-for';
+import 'imagesloaded';
 
 function setFlickityOnGallery($gallery) {
   const $items = $gallery.find('.gallery-item');
@@ -20,7 +20,7 @@ function setFlickityOnGallery($gallery) {
   });
 
   // Instantiate Flickity gallery
-  const flkty = new Flickity($gallery.get(0), {
+  new Flickity($gallery.get(0), {
     pageDots: false,
     fullscreen: true,
     setGallerySize: true,
@@ -55,7 +55,7 @@ function setFlickityGalleryNav($galleryNav) {
       $galleryNav.addClass('ready');
 
       // Instantiate Flickity nav
-      const flkty = new Flickity($galleryNav.get(0), {
+      new Flickity($galleryNav.get(0), {
         asNavFor: `#${target}`,
         cellAlign: 'left',
         pageDots: false,
@@ -69,7 +69,6 @@ function setFlickityGalleryNav($galleryNav) {
 }
 
 export default () => {
-  window.flickityInstances = [];
   const $galleries = $('.gallery');
 
   // Base gallery logic


### PR DESCRIPTION
- `window.flickityInstances` is unused by us, and Google doesn't know about it either
- `Imagesloaded` is not used; keep the import for its side effects (i.e. making `$().imagesLoaded` work)
- Proceed likewise for two `import` lines that had a `// eslint-disable-line` for precisely this reason
- The calls to `new Flickity` are apparently used only for their side effects; remove the variable assignment that used to come with them.