### PR TITLE
Fix checkbox and radio position in checked state

### DIFF
--- a/assets/components/molecules/question/question.scss
+++ b/assets/components/molecules/question/question.scss
@@ -141,16 +141,16 @@ $animation: 0.2s;
     .custom-control-label-content {
       margin-bottom: -1px;
     }
+
+    // checked styles
+    .custom-control-input:checked + .custom-control-label {
+      @include trapeze-span-vertical-container-active();
+      z-index: $zindex-10;
+    }
   }
 
   .question-content {
     padding: $spacer 0;
-  }
-
-  // checked styles
-  .custom-control-input:checked + .custom-control-label {
-    @include trapeze-span-vertical-container-active();
-    z-index: $zindex-10;
   }
 }
 
@@ -190,6 +190,11 @@ $animation: 0.2s;
       height: 100%;
       margin-left: -1px;
     }
+
+    // checked styles
+    .custom-control-input:checked + .custom-control-label {
+      @include trapeze-span-horizontal-container-active();
+    }
   }
 
   .question-img {
@@ -210,10 +215,5 @@ $animation: 0.2s;
 
   .question-content {
     padding: 0 4rem;
-  }
-
-  // checked styles
-  .custom-control-input:checked + .custom-control-label {
-    @include trapeze-span-horizontal-container-active();
   }
 }


### PR DESCRIPTION
**Description**

Quand on clique sur une option des 'checkbox' ou 'radio', il y a un décalage vers le haut ou la droite en fonction de la largeur d'écrans. Le problème a été introduit dans la version 3.6.0 lors du passage à une version moderne de sass.

**Etapes pour reproduire**

1. Aller sur https://epfl-si.github.io/elements/#/atoms/checkbox/states/full ou https://epfl-si.github.io/elements/#/atoms/radio/list/full
2. Cliquer sur une option

**Screenshots**

| Checkbox  | Radio  | 
|---|---|
| ![Screenshot from 2023-02-10 16-23-37](https://user-images.githubusercontent.com/2843501/218134604-1320e817-3593-4939-b1f2-ef55d90324e3.png) | ![Screenshot from 2023-02-10 16-23-54](https://user-images.githubusercontent.com/2843501/218134641-dfc76f4e-2f9e-4cf1-be82-3f9cb17d40c7.png) |
