### PR TITLE
Fix stylelint issues in reader

### DIFF
--- a/reader/components/App/App.scss
+++ b/reader/components/App/App.scss
@@ -1,4 +1,4 @@
-@import '../../variables.scss';
+@import '../../variables';
 
 body {
   margin: 0;
@@ -8,11 +8,7 @@ body {
 .tlbx-h2 { text-align: center; }
 
 .styleguide {
-  display: flex;
-  display: -ms-grid;
   display: grid;
-  -ms-grid-template-columns: 60px 240px 1fr;
-  grid-template-columns: 60px 240px 1fr;
   grid-template-columns: $toolbar-width 240px 1fr;
   min-height: 100vh;
   max-width: 100%;
@@ -26,52 +22,52 @@ body {
 }
 
 .tlbx-toolbar-wrapper {
-  position: fixed;
   display: flex;
-  flex-direction: column;
-  padding: 5px;
-  z-index: 999;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  width: $toolbar-width;
-  box-sizing: border-box;
   flex: 0 0 $toolbar-width;
-  grid-column: 1;
-  background-color: $color-primary;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: $toolbar-width;
+  padding: 5px;
   color: white;
 
+  flex-direction: column;
+
+  z-index: 999;
+  box-sizing: border-box;
+  grid-column: 1;
+  background-color: $color-primary;
+
   @media only screen and (max-width: 767px) {
-    width: 100%;
     bottom: auto;
+    width: 100%;
   }
 }
 
 .tlbx-sidebar-wrapper {
   flex: 0 0 240px;
-  -ms-grid-column: 2;
   grid-column: 2;
   background-color: $gray-lighter;
 
   @media only screen and (max-width: 767px) {
     position: fixed;
-    z-index: 998;
     top: $toolbar-width;
-    bottom: 0;
     right: 0;
+    bottom: 0;
+    transform: translateX(100%);
+    transition: transform 0.3s;
+    z-index: 998;
     overflow-y: auto;
     min-height: 100vh;
     max-width: 240px;
     box-shadow: -3px 0 20px 0 rgba(0, 0, 0, 0.3);
-    transform: translateX(100%);
-    transition: transform 0.3s;
     &.tlbx-sidebar-open { transform: translateX(0); }
   }
 }
 
 .tlbx-content-wrapper {
   flex: 1 1 auto;
-  -ms-grid-column: 3;
   grid-column: 3;
   align-self: start;
   overflow: hidden;

--- a/reader/components/ColorTable/ColorTable.scss
+++ b/reader/components/ColorTable/ColorTable.scss
@@ -1,4 +1,4 @@
-@import '../../variables.scss';
+@import '../../variables';
 
 .tlbx-table-wrapper {
   max-width: 100%;
@@ -20,8 +20,8 @@
     vertical-align: bottom;
 
     .tblx-muted {
-      line-height: 1.1em;
       display: inline-block;
+      line-height: 1.1em;
     }
   }
 
@@ -50,10 +50,10 @@
 }
 
 .tlbx-contrast-color-thumb {
+  font-size: 1.2rem;
+  font-weight: bold;
   align-items: center;
   justify-content: center;
-  font-weight: bold;
-  font-size: 1.2rem;
 }
 
 .tlbx-contrast-none {
@@ -62,12 +62,12 @@
   overflow: hidden;
 }
 
-.tlbx-contrast-none::after {
+.tlbx-contrast-none:after {
   content: '';
   position: absolute;
-  left: 0;
   top: 1px;
   bottom: 1px;
+  left: 0;
   width: 200%;
   border-width: 40px;
   border-style: solid;
@@ -77,8 +77,8 @@
 .tlbx-contrast-text {
   display: inline-block;
   width: 100%;
-  font-weight: bold;
   font-size: 2rem;
+  font-weight: bold;
   text-align: center;
 }
 

--- a/reader/components/Icon/Icon.scss
+++ b/reader/components/Icon/Icon.scss
@@ -1,17 +1,17 @@
-@import '../../variables.scss';
+@import '../../variables';
 
 $icon-size-base: 1em;
 
 .tblx-icon {
   display: inline-flex;
-  align-self: center;
   position: relative;
   top: 0.1em;
   width: $icon-size-base;
   height: $icon-size-base;
-  line-height: 1em;
   font-size: 1em;
+  line-height: 1em;
   color: inherit;
-  fill: currentColor;
   transition: transform 0.2s;
+  align-self: center;
+  fill: currentColor;
 }

--- a/reader/components/Item/Item.scss
+++ b/reader/components/Item/Item.scss
@@ -1,4 +1,4 @@
-@import '../../variables.scss';
+@import '../../variables';
 
 .tlbx-item-preview {
   position: relative;
@@ -29,13 +29,13 @@
 
 .tlbx-actions-link {
   position: relative;
-  z-index: 1;
   padding: 0 0.5em;
   border: 1px solid $link-color;
+  font-size: 12px;
+  color: $link-color;
+  z-index: 1;
   background-color: #fff;
   border-radius: 3px;
-  color: $link-color;
-  font-size: 12px;
   text-decoration: none;
 
   &:hover {

--- a/reader/components/Loader/Loader.scss
+++ b/reader/components/Loader/Loader.scss
@@ -1,13 +1,13 @@
-@import '../../variables.scss';
+@import '../../variables';
 
 .tblx-loader {
+  display: flex;
+  width: 100%;
+  height: 100%;
   padding: 30px;
   color: #003baf;
   text-align: center;
-  display: flex;
   justify-content: center;
   align-items: center;
-  width: 100%;
-  height: 100%;
   .tlbx-item-preview & { padding: 5px; }
 }

--- a/reader/components/Sidebar/Sidebar.scss
+++ b/reader/components/Sidebar/Sidebar.scss
@@ -1,4 +1,4 @@
-@import '../../variables.scss';
+@import '../../variables';
 
 .tlbx-sidebar {
   padding: 1em 0;
@@ -15,8 +15,8 @@
 }
 
 .tlbx-sidebar-title {
-  font-size: 1rem;
   margin: 0 1rem;
+  font-size: 1rem;
   margin-top: 0.5rem;
 
   span {
@@ -30,4 +30,3 @@
   font-size: 0.8rem;
   font-weight: 200;
 }
-

--- a/reader/components/SidebarItem/SidebarItem.scss
+++ b/reader/components/SidebarItem/SidebarItem.scss
@@ -1,16 +1,16 @@
-@import '../../variables.scss';
+@import '../../variables';
 
 .tlbx-sidebar-item {
   display: flex;
-  margin: 0 0 0.5rem 0;
   width: 100%;
+  margin: 0 0 0.5rem 0;
+  background: none;
+  border: 0;
+  font-size: 1rem;
   padding-right: 1rem;
   padding-left: 1rem;
-  border: 0;
-  background: none;
   cursor: pointer;
   text-transform: capitalize;
-  font-size: 1rem;
 
   &:hover {
     color: $link-hover-color;
@@ -24,18 +24,17 @@
 
   &:after {
     content: '';
+    display: block;
+    width: 0;
+    height: 0;
+    font-size: 0;
     line-height: 0;
     align-self: center;
     margin-left: auto;
     margin-right: 1rem;
-    display: block;
-    width: 0;
-    height: 0;
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
     border-top: 5px solid $link-color;
-    font-size: 0;
-    line-height: 0;
   }
 
   .tlbx-open & {

--- a/reader/components/Toolbar/Toolbar.scss
+++ b/reader/components/Toolbar/Toolbar.scss
@@ -1,4 +1,4 @@
-@import '../../variables.scss';
+@import '../../variables';
 
 .tlbx-toolbar {
   display: flex;
@@ -14,15 +14,15 @@
 
 .tlbx-toolbar-btn {
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
   width: $toolbar-width - 10px;
   height: 50px;
-  border: none;
   background: none;
-  color: #fff;
-  font-weight: 900;
+  border: none;
   font-size: 1.4em;
+  font-weight: 900;
+  color: #fff;
+  align-items: center;
+  justify-content: center;
   opacity: 1;
 
   &:hover { cursor: pointer; }

--- a/reader/reader.scss
+++ b/reader/reader.scss
@@ -1,5 +1,6 @@
 @charset 'utf-8';
 
+@use 'sass:map';
 @import 'variables';
 @import 'bootstrap/scss/functions';
 // Import the main theme's Bootstrap config:
@@ -19,7 +20,7 @@
 
 
 .tlbx-doc-markdown-wrapper {
-  max-width: map-get($container-max-widths, 'md');
+  max-width: map.get($container-max-widths, 'md');
   margin: 0 auto;
 }
 

--- a/reader/views/Colors/Colors.scss
+++ b/reader/views/Colors/Colors.scss
@@ -1,4 +1,4 @@
-@import '../../variables.scss';
+@import '../../variables';
 
 .tlbx-color-swatch-wrapper {
   display: flex;
@@ -23,14 +23,14 @@
 }
 
 .tlbx-color-swatch-btn {
-  opacity: 0;
   display: inline-block;
   margin: 0 auto;
   padding: 1em;
   background: $color-primary;
-  color: $white;
   border: none;
+  color: $white;
   transition: opacity 0.3s;
+  opacity: 0;
   &:hover { cursor: pointer; }
 }
 

--- a/reader/views/Doc/Doc.scss
+++ b/reader/views/Doc/Doc.scss
@@ -1,1 +1,1 @@
-@import '../../variables.scss';
+@import '../../variables';

--- a/reader/views/Single/Single.scss
+++ b/reader/views/Single/Single.scss
@@ -1,4 +1,4 @@
-@import '../../variables.scss';
+@import '../../variables';
 
 .tlbx-notes {
   max-width: 700px;
@@ -13,8 +13,8 @@
   }
 
   .tlbx-single-full-intro h1 {
-    font-size: 1rem;
     margin: 0;
+    font-size: 1rem;
   }
 }
 


### PR DESCRIPTION
```bash
./node_modules/.bin/stylelint "reader/**/*.scss"

reader/reader.scss
 22:14  ✖  Expected map.get instead of map-get  scss/no-global-function-names

reader/components/App/App.scss
  1:26  ✖  Unexpected extension ".scss" in @import               scss/at-import-partial-extension
 12:12  ✖  Unexpected vendor-prefix "-ms-grid"                   value-no-vendor-prefix
 14:3   ✖  Unexpected vendor-prefix "-ms-grid-template-columns"  property-no-vendor-prefix
 30:3   ✖  Expected "display" to come before "position"          order/properties-order
 34:3   ✖  Expected "top" to come before "padding"               order/properties-order
 36:3   ✖  Expected "bottom" to come before "left"               order/properties-order
 39:3   ✖  Expected "flex" to come before "width"                order/properties-order
 46:5   ✖  Expected "bottom" to come before "width"              order/properties-order
 52:3   ✖  Unexpected vendor-prefix "-ms-grid-column"            property-no-vendor-prefix
 61:5   ✖  Expected "right" to come before "bottom"              order/properties-order
 74:3   ✖  Unexpected vendor-prefix "-ms-grid-column"            property-no-vendor-prefix

reader/components/Icon/Icon.scss
  1:26  ✖  Unexpected extension ".scss" in @import            scss/at-import-partial-extension
 13:3   ✖  Expected "font-size" to come before "line-height"  order/properties-order

reader/components/ColorTable/ColorTable.scss
  1:26  ✖  Unexpected extension ".scss" in @import            scss/at-import-partial-extension
 24:7   ✖  Expected "display" to come before "line-height"    order/properties-order
 56:3   ✖  Expected "font-size" to come before "font-weight"  order/properties-order
 65:20  ✖  Expected single colon pseudo-element notation      selector-pseudo-element-colon-notation
 69:3   ✖  Expected "top" to come before "left"               order/properties-order
 81:3   ✖  Expected "font-size" to come before "font-weight"  order/properties-order

reader/components/Item/Item.scss
  1:26  ✖  Unexpected extension ".scss" in @import      scss/at-import-partial-extension
 38:3   ✖  Expected "font-size" to come before "color"  order/properties-order

reader/components/Loader/Loader.scss
 1:26  ✖  Unexpected extension ".scss" in @import    scss/at-import-partial-extension
 7:3   ✖  Expected "display" to come before "color"  order/properties-order

reader/components/Sidebar/Sidebar.scss
  1:26  ✖  Unexpected extension ".scss" in @import       scss/at-import-partial-extension
 19:3   ✖  Expected "margin" to come before "font-size"  order/properties-order

reader/components/SidebarItem/SidebarItem.scss
  1:26  ✖  Unexpected extension ".scss" in @import          scss/at-import-partial-extension
  6:3   ✖  Expected "width" to come before "margin"         order/properties-order
 10:3   ✖  Expected "background" to come before "border"    order/properties-order
 31:5   ✖  Expected "display" to come before "line-height"  order/properties-order
 38:5   ✖  Unexpected duplicate "line-height"               declaration-block-no-duplicate-properties
 38:5   ✖  Unexpected duplicate "line-height"               declaration-block-no-duplicate-properties

reader/components/Toolbar/Toolbar.scss
  1:26  ✖  Unexpected extension ".scss" in @import            scss/at-import-partial-extension
 22:3   ✖  Expected "background" to come before "border"      order/properties-order
 24:3   ✖  Expected "font-weight" to come before "color"      order/properties-order
 25:3   ✖  Expected "font-size" to come before "font-weight"  order/properties-order

reader/views/Colors/Colors.scss
  1:26  ✖  Unexpected extension ".scss" in @import   scss/at-import-partial-extension
 32:3   ✖  Expected "border" to come before "color"  order/properties-order

reader/views/Doc/Doc.scss
 1:26  ✖  Unexpected extension ".scss" in @import  scss/at-import-partial-extension

reader/views/Single/Single.scss
  1:26  ✖  Unexpected extension ".scss" in @import       scss/at-import-partial-extension
 17:5   ✖  Expected "margin" to come before "font-size"  order/properties-order

41 problems (41 errors, 0 warnings)
``` 