### PR TITLE
Fix stylelint issues in assets

### DIFF
--- a/assets/components/atoms/alert/alert.scss
+++ b/assets/components/atoms/alert/alert.scss
@@ -1,5 +1,5 @@
 @charset 'utf-8';
-@use "sass:color";
+@use 'sass:color';
 
 $alert-icon-size: 2rem;
 $alert-icons: (

--- a/assets/components/atoms/alert/alert.scss
+++ b/assets/components/atoms/alert/alert.scss
@@ -1,4 +1,5 @@
 @charset 'utf-8';
+@use "sass:color";
 
 $alert-icon-size: 2rem;
 $alert-icons: (
@@ -30,8 +31,8 @@ $alert-icons: (
 @each $color, $value in $theme-colors {
   .alert-#{$color} {
     border-color: $value;
-    hr { border-top-color: darken($value, 5%); }
-    .alert-link { color: darken($value, 10%); }
+    hr { border-top-color: color.adjust($value, $lightness: -5%); }
+    .alert-link { color: color.adjust($value, $lightness: -10%); }
   }
 }
 

--- a/assets/components/atoms/button/button.scss
+++ b/assets/components/atoms/button/button.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @charset 'utf-8';
 
 .btn {
@@ -32,8 +33,8 @@
   &:not(:disabled):not(.disabled).active {
     // ugly ↓
     // background: linear-gradient(to bottom, $red-dark 0%, $red 100%);
-    background: darken($red-dark, 10%);
-    border-color: darken($red-dark, 10%);
+    background: color.adjust($red-dark, $lightness: -10%);
+    border-color: color.adjust($red-dark, $lightness: -10%);
   }
 
   &:disabled,

--- a/assets/components/atoms/button/button.scss
+++ b/assets/components/atoms/button/button.scss
@@ -1,5 +1,5 @@
-@use "sass:color";
 @charset 'utf-8';
+@use 'sass:color';
 
 .btn {
   text-decoration: none;

--- a/assets/components/atoms/collapse/collapse.scss
+++ b/assets/components/atoms/collapse/collapse.scss
@@ -38,11 +38,11 @@ $collapse-chevron-size: 12px;
 }
 
 .collapse-title {
-  color: $black;
   position: relative;
   padding: 0;
   background: none;
   border: none;
+  color: $black;
   transition: box-shadow 0.25s, color 0.15s;
 
   &:before {
@@ -72,7 +72,7 @@ $collapse-chevron-size: 12px;
 
   &.collapse-title-desktop {
     @include collapse-btn();
-    
+
     &:hover,
     &:focus,
     &:active {
@@ -94,7 +94,7 @@ $collapse-chevron-size: 12px;
 }
 
 .collapse-item {
-  &::after {
+  &:after {
     content: "";
     display: block;
     padding-top: 2rem;
@@ -136,7 +136,7 @@ header.collapse-title {
 }
 
 header.collapse-title + .collapse-item {
-  &::before {
+  &:before {
     content: "";
     display: block;
     padding-top: 0.5rem;
@@ -272,6 +272,6 @@ $collapse-drop-margin: ($grid-gutter-width * 0.3);
 // helper classes to define partial collapse defaut height
 @for $i from 0 to 10 {
   .collapse-partial-#{$i}:not(.show) {
-    height: #{$i*2}rem;
+    height: #{$i * 2}rem;
   }
 }

--- a/assets/components/atoms/list/list.scss
+++ b/assets/components/atoms/list/list.scss
@@ -97,9 +97,9 @@ ol {
   ul {
 
     & > li:before {
+      top: 0.7rem;
       background: transparent;
       border: 1px solid $red;
-      top: 0.7rem;
     }
   }
 }

--- a/assets/components/atoms/popover/popover.scss
+++ b/assets/components/atoms/popover/popover.scss
@@ -1,5 +1,5 @@
 @charset 'utf-8';
-@use "sass:color";
+@use 'sass:color';
 
 $popover-border-bottom-color: $black;
 

--- a/assets/components/atoms/popover/popover.scss
+++ b/assets/components/atoms/popover/popover.scss
@@ -1,4 +1,5 @@
 @charset 'utf-8';
+@use "sass:color";
 
 $popover-border-bottom-color: $black;
 
@@ -65,7 +66,7 @@ $popover-border-bottom-color: $black;
     }
 
     @include hover {
-      color: darken($link-hover-color, 5%);
+      color: color.adjust($link-hover-color, $lightness: -5%);
     }
   }
 }

--- a/assets/components/atoms/range/range.scss
+++ b/assets/components/atoms/range/range.scss
@@ -13,6 +13,6 @@
   }
 
   &::-webkit-slider-runnable-track {
-    background: linear-gradient($red, $red) 0/var(--sx) 100% no-repeat $custom-range-track-bg;
+    background: linear-gradient($red, $red) 0 / var(--sx) 100% no-repeat $custom-range-track-bg;
   }
 }

--- a/assets/components/atoms/select/select.scss
+++ b/assets/components/atoms/select/select.scss
@@ -55,8 +55,8 @@
     text-overflow: ellipsis;
 
     &.placeholder {
-      color: $input-placeholder-color;
       font-size: 1rem;
+      color: $input-placeholder-color;
     }
   }
 
@@ -104,7 +104,7 @@
       list-style: none;
       background-image: none;
       padding-left: 0;
-      
+
       &:before {
         content: none;
       }

--- a/assets/components/atoms/tag/tag.scss
+++ b/assets/components/atoms/tag/tag.scss
@@ -1,11 +1,12 @@
 @charset 'utf-8';
+@use "sass:color";
 
 a.tag {
   &:hover {
     background: $gray-100;
-    border-top-color: darken($gray-300, 10%);
-    border-right-color: darken($gray-300, 10%);
-    border-left-color: darken($gray-300, 10%);
+    border-top-color: color.adjust($gray-300, $lightness: -10%);
+    border-right-color: color.adjust($gray-300, $lightness: -10%);
+    border-left-color: color.adjust($gray-300, $lightness: -10%);
     color: $black;
     text-decoration: none;
   }
@@ -69,7 +70,7 @@ a.tag {
 
 .tag-group {
   padding: 1em;
-  background: darken($white, 5%);
+  background: color.adjust($white, $lightness: -5%);
   border-radius: $border-radius;
   border: 1px solid $gray-300;
 
@@ -90,7 +91,7 @@ a.tag {
 
   .selectize-input {
     padding: 0.3em 0.2em 0.1em;
-    background: darken($white, 5%);
+    background: color.adjust($white, $lightness: -5%);
     border-radius: $border-radius;
     border: 1px solid $gray-300;
   }
@@ -114,9 +115,9 @@ a.tag {
       &.active,
       &:hover {
         background: $gray-100;
-        border-top-color: darken($gray-300, 10%);
-        border-right-color: darken($gray-300, 10%);
-        border-left-color: darken($gray-300, 10%);
+        border-top-color: color.adjust($gray-300, $lightness: -10%);
+        border-right-color: color.adjust($gray-300, $lightness: -10%);
+        border-left-color: color.adjust($gray-300, $lightness: -10%);
         color: $black;
         text-decoration: none;
       }
@@ -154,7 +155,7 @@ a.tag {
 
       &:hover,
       &.active {
-        background-color: lighten($gray-100, 5%);
+        background-color: color.adjust($gray-100, $lightness: 5%);
         color: $body-color;
       }
     }

--- a/assets/components/atoms/tag/tag.scss
+++ b/assets/components/atoms/tag/tag.scss
@@ -1,5 +1,5 @@
 @charset 'utf-8';
-@use "sass:color";
+@use 'sass:color';
 
 a.tag {
   &:hover {

--- a/assets/components/content-types/event/event.scss
+++ b/assets/components/content-types/event/event.scss
@@ -23,7 +23,7 @@
 // List
 
 .list-events {
-  
+
   .list-group-teaser-content {
     .card-title {
       max-width: 660px;
@@ -34,22 +34,22 @@
       }
     }
   }
-  
+
   @include media-breakpoint-up(xl) {
-    
+
     .list-group-teaser-content {
-    
+
       .event-actions {
         position: absolute;
         top: 0;
         right: 1rem;
-        
+
         @for $i from 1 through 7 {
           .col-md-#{$i} & {
             position: static;
           }
         }
-        
+
       }
     }
   }
@@ -58,20 +58,20 @@
 // Featured events
 
 .list-group.list-events-featured {
-  
+
   .list-group-teaser {
     background: transparent;
     margin-bottom: 1rem;
-    
+
     &:last-child {
       margin-bottom: 0;
     }
   }
-  
+
   .list-group-teaser-container {
+    height: 100%;
     background: #fff;
     flex-direction: column;
-    height: 100%;
 
     .btn-secondary {
       &:hover,
@@ -81,15 +81,15 @@
       }
     }
   }
-  
+
   .list-group-teaser-content {
-    
+
     .event-actions {
       position: static;
-      
+
       .btn {
         width: 100%;
-        
+
         & + .btn {
           margin-left: 0;
           margin-top: 0.75rem;
@@ -97,36 +97,36 @@
       }
     }
   }
-  
+
   @include media-breakpoint-up(lg) {
     flex-direction: row;
     margin-left: -10px;
     margin-right: -10px;
-    
+
     .list-group-teaser {
       margin-bottom: 0;
       padding-left: 10px;
       padding-right: 10px;
-      
+
       & + .list-group-teaser {
         margin-top: 0;
       }
     }
-    
+
     .list-group-teaser-thumbnail {
       padding-bottom: 0;
     }
-    
+
     .list-group-teaser-content {
       display: flex;
       flex-direction: column;
-      
+
       .card-info {
         display: flex;
         flex-direction: column;
         height: 100%;
       }
-      
+
       .event-actions {
         margin-top: auto;
       }
@@ -137,19 +137,19 @@
 // Events page
 
 .events-links {
-  
+
   @include media-breakpoint-up(lg) {
     ul {
       margin-bottom: 0;
     }
   }
-  
+
   li {
     display: inline-block;
     font-size: 1rem;
     font-weight: bold;
     margin-right: 1rem;
-    
+
     &:last-child {
       margin-right: 0;
     }

--- a/assets/components/content-types/study-plan/study-plan.scss
+++ b/assets/components/content-types/study-plan/study-plan.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @charset 'utf-8';
 
 $table-cours-template-columns: minmax(200px, 3fr) minmax(auto, 1fr) minmax(200px, 3fr);
@@ -332,7 +333,7 @@ $study-plan-master-pdm: minmax(250px, 3fr) 1fr 2fr 2fr 2fr 2fr minmax(140px, 3fr
 
       .cep:nth-child(2),
       .bachlor:nth-child(4) .cep {
-        background-color: darken($table-head-bg, 4%);
+        background-color: color.adjust($table-head-bg, $lightness: -4%);
       }
 
       .bachlor:nth-child(4) .cep:nth-child(2) {

--- a/assets/components/content-types/study-plan/study-plan.scss
+++ b/assets/components/content-types/study-plan/study-plan.scss
@@ -1,5 +1,5 @@
-@use "sass:color";
 @charset 'utf-8';
+@use 'sass:color';
 
 $table-cours-template-columns: minmax(200px, 3fr) minmax(auto, 1fr) minmax(200px, 3fr);
 $table-grid-template-columns: 1fr $table-cours-template-columns 2fr 2fr 2fr minmax(200px, 3fr) 1fr;
@@ -341,17 +341,6 @@ $study-plan-master-pdm: minmax(250px, 3fr) 1fr 2fr 2fr 2fr 2fr minmax(140px, 3fr
       }
     }
   }
-
-  // Maybe we'll have to handle those colors in some way.
-  //.bachlor {
-  //  &.local-color {
-  //    background-color: $table-border-color;
-  //  }
-  //
-  //  &.local-color-light {
-  //    background-color: gray('100');
-  //  }
-  //}
 
   .clear {
     display: none;

--- a/assets/components/entrypoint.scss
+++ b/assets/components/entrypoint.scss
@@ -8,15 +8,14 @@
 @import '../config/layout';
 @import '../config/helpers';
 @import '../config/wordpress';
-@import '../../node_modules/tablesaw/src/tables.stack-mixin.scss';
+@import '../../node_modules/tablesaw/src/tables.stack-mixin';
 
 // site:
-@import './site.scss';
+@import './site';
 
 // Don't edit the following sections, they should always be preceded by a blank
 // line
 
-//
 // atoms:
 @import 'atoms/button/button';
 @import 'atoms/tag/tag';
@@ -47,7 +46,6 @@
 @import 'atoms/loader/loader';
 @import 'atoms/favicon/favicon';
 
-//
 // molecules:
 @import 'molecules/search/search';
 @import 'molecules/access-nav/access-nav';
@@ -99,7 +97,6 @@
 @import 'organisms/cookie-consent/cookie-consent';
 @import 'organisms/faq/faq';
 
-//
 // content-types:
 @import 'content-types/coursebook/coursebook';
 @import 'content-types/event/event';
@@ -123,7 +120,6 @@
 @import 'content-types/project/project';
 @import 'content-types/project-list/project-list';
 
-//
 // pages:
 @import 'pages/people-detail/people-detail';
 @import 'pages/blog-single/blog-single';

--- a/assets/components/molecules/card/card.scss
+++ b/assets/components/molecules/card/card.scss
@@ -1,7 +1,6 @@
 @charset 'utf-8';
 @use 'sass:math';
 
-//
 // Normal card
 .card {
   border-color: $gray-100;
@@ -79,7 +78,6 @@ a.card-gray:hover .card-body { background: $white; }
   border: 0;
 }
 
-//
 // Distinction is when you have a little red fancy flag in the card body.
 .card-distinction .card-body {
   position: relative;
@@ -97,7 +95,6 @@ a.card-gray:hover .card-body { background: $white; }
   }
 }
 
-//
 // Card info
 .card-info {
   font-size: $font-size-sm;
@@ -118,6 +115,35 @@ a.card-gray:hover .card-body { background: $white; }
   .event-info:after,
   .event-info-date:after {
     content: none;
+  }
+
+  .event-date:not(:last-child):after {
+    content: ' \2013 ';
+  }
+
+  .event-time:not(:last-of-type) {
+    &:after {
+      content: ' \203A ';
+      margin: 0 0.25em 0 0.15em;
+    }
+  }
+
+  .event-info-date {
+    .event-date,
+    .event-time,
+    .icon {
+      display: inline-block;
+      vertical-align: middle;
+    }
+    .icon {
+      width: 18px;
+      height: 18px;
+      color: $gray-600;
+    }
+  }
+
+  .event-info > span {
+    display: block;
   }
 
   a {
@@ -160,39 +186,6 @@ a.card-gray:hover .card-body { background: $white; }
   padding: ($spacer * 0.25) 0;
 }
 
-.card-info {
-
-  .event-date:not(:last-child):after {
-    content: ' \2013 ';
-  }
-
-  .event-time:not(:last-of-type) {
-    &:after {
-      content: ' \203A ';
-      margin: 0 0.25em 0 0.15em;
-    }
-  }
-
-  .event-info-date {
-    .event-date,
-    .event-time,
-    .icon {
-      display: inline-block;
-      vertical-align: middle;
-    }
-    .icon {
-      color: $gray-600;
-      height: 18px;
-      width: 18px;
-    }
-  }
-
-  .event-info > span {
-    display: block;
-  }
-}
-
-//
 // Card items as links
 a.card-img-top {
   position: relative;
@@ -228,7 +221,6 @@ a.card-title,
   }
 }
 
-//
 // Whole card as a link
 a.card {
   text-decoration: none;
@@ -254,7 +246,6 @@ a.card {
   }
 }
 
-//
 // Card overlay image
 .card-img-overlay {
   right: auto;
@@ -279,7 +270,6 @@ a.card {
   min-height: 1px;
 }
 
-//
 // Grayscale look, see event finished
 .card-grayscale {
   &:hover {

--- a/assets/components/molecules/footnotes/footnotes.scss
+++ b/assets/components/molecules/footnotes/footnotes.scss
@@ -1,5 +1,5 @@
 @charset 'utf-8';
-@use "sass:color";
+@use 'sass:color';
 
 article {
   counter-reset: footnotes;

--- a/assets/components/molecules/footnotes/footnotes.scss
+++ b/assets/components/molecules/footnotes/footnotes.scss
@@ -1,4 +1,5 @@
 @charset 'utf-8';
+@use "sass:color";
 
 article {
   counter-reset: footnotes;
@@ -106,5 +107,5 @@ article {
  * Highlight target note
  */
 footer :target {
-  background: transparentize($red, 0.8);
+  background: color.adjust($red, $alpha: -0.8);
 }

--- a/assets/components/molecules/form-group/form-group.scss
+++ b/assets/components/molecules/form-group/form-group.scss
@@ -21,24 +21,24 @@
 
 .search-container {
   position: relative;
-  
+
   input[type="search"] {
     padding-right: 40px;
   }
-  
+
   .icon {
-    color: $gray-300;
     position: absolute;
     top: 50%;
     right: $input-padding-x;
+    color: $gray-300;
     transform: translateY(-50%);
     transition: color 0.3s;
   }
-  
+
   input[type="search"]:hover + .icon {
     color: $gray-600;
   }
-  
+
   input[type="search"]:focus + .icon {
     color: $black;
   }

--- a/assets/components/molecules/tabs/tabs.scss
+++ b/assets/components/molecules/tabs/tabs.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @charset 'utf-8';
 
 .nav-tabs {
@@ -41,7 +42,7 @@
 
     &:hover {
       z-index: $zindex-1;
-      background-color: darken(gray('100'), 5%);
+      background-color: color.adjust(gray('100'), $lightness: -5%);
       color: $body-color;
     }
 
@@ -54,11 +55,11 @@
 
     &:active {
       z-index: $zindex-1;
-      background: linear-gradient(0deg, gray('100') 0%, darken(gray('100'), 5%) 100%);
+      background: linear-gradient(0deg, gray('100') 0%, color.adjust(gray('100'), $lightness: -5%) 100%);
     }
 
     &.disabled {
-      background-color: darken(gray('100'), 5%);
+      background-color: color.adjust(gray('100'), $lightness: -5%);
       border-color: $nav-tabs-border-color;
       color: gray('300');
       cursor: not-allowed;

--- a/assets/components/molecules/tabs/tabs.scss
+++ b/assets/components/molecules/tabs/tabs.scss
@@ -1,5 +1,5 @@
-@use "sass:color";
 @charset 'utf-8';
+@use 'sass:color';
 
 .nav-tabs {
   .nav-item {

--- a/assets/components/organisms/fullwidth-teaser/fullwidth-teaser.scss
+++ b/assets/components/organisms/fullwidth-teaser/fullwidth-teaser.scss
@@ -1,5 +1,8 @@
 @charset 'utf-8';
+
 @use 'sass:math';
+@use "sass:color";
+@use "sass:map";
 
 .fullwidth-teaser {
   position: relative;
@@ -91,7 +94,7 @@
 
   @include make-col(12, 12);
 
-  max-width: map-get($grid-breakpoints, 'xl');
+  max-width: map.get($grid-breakpoints, 'xl');
 
   @include media-breakpoint-up(md) {
     padding: 1rem $grid-gutter-width 0;
@@ -172,7 +175,7 @@
 
     &:hover,
     &:focus {
-      background: darken($red, 15%);
+      background: color.adjust($red, $lightness: -15%);
       color: $white;
 
       @include media-breakpoint-up(xl) {
@@ -182,7 +185,7 @@
       &:before,
       &:after {
         background: none;
-        border-top-color: darken($red, 15%);
+        border-top-color: color.adjust($red, $lightness: -15%);
       }
     }
   }
@@ -202,7 +205,7 @@
 
 .fullwidth-teaser-footer {
   margin-bottom: math.div($grid-gutter-width, 2);
-  
+
   &:last-child {
     margin-bottom: 0;
   }

--- a/assets/components/organisms/fullwidth-teaser/fullwidth-teaser.scss
+++ b/assets/components/organisms/fullwidth-teaser/fullwidth-teaser.scss
@@ -1,8 +1,8 @@
 @charset 'utf-8';
 
 @use 'sass:math';
-@use "sass:color";
-@use "sass:map";
+@use 'sass:color';
+@use 'sass:map';
 
 .fullwidth-teaser {
   position: relative;

--- a/assets/components/organisms/header/header.scss
+++ b/assets/components/organisms/header/header.scss
@@ -156,8 +156,8 @@
   }
 
   p.site-title {
-    font-weight: 700;
     line-height: 1.1em;
+    font-weight: 700;
   }
 
   .drawer {

--- a/assets/components/organisms/nav-main/nav-main.scss
+++ b/assets/components/organisms/nav-main/nav-main.scss
@@ -2,9 +2,7 @@
 
 $nav-spacer: 4px;
 
-//
 // Inner nav styles
-//
 .nav-main {
   position: relative;
   background: color('white');
@@ -134,9 +132,9 @@ a.nav-arrow {
   position: relative;
   margin-top: $nav-spacer;
   margin-bottom: $nav-spacer;
-  padding: (0 $nav-spacer) (0 $nav-spacer+1) !important;
+  padding: (0 $nav-spacer) (0 $nav-spacer + 1) !important;
   font-size: 1.3 * $font-size-base !important;
-  line-height: 1  * $font-size-base !important;
+  line-height: 1 * $font-size-base !important;
   font-weight: normal !important;
 
   .icon-container {
@@ -175,10 +173,8 @@ a.nav-arrow {
   }
 }
 
-//
 // Vertical scroll for menu toggle
 // horizontal slide of menus
-//
 .nav-wrapper {
   width: 100%;
   height: 100%;
@@ -207,9 +203,7 @@ a.nav-arrow {
   padding-left: 100%;
 }
 
-//
 // Desktop
-//
 @include media-breakpoint-up(xl) {
   // Solid nav
   .nav-solid-layout {
@@ -284,9 +278,8 @@ a.nav-arrow {
   }
 }
 
-//
+
 // Mobile
-//
 @include media-breakpoint-down(lg) {
   .main-container {
     position: relative;
@@ -350,19 +343,13 @@ a.nav-arrow {
       bottom: 0;
     }
 
-    .nav-lang {
-      //bottom: 0;
-    }
-
     .nav-lang-mobile {
       display: block;
     }
   }
 }
 
-//
 // Overlay
-//
 .overlay {
   content: ' ';
   position: fixed;

--- a/assets/components/pages/error-404/error-404.scss
+++ b/assets/components/pages/error-404/error-404.scss
@@ -1,7 +1,7 @@
 
 .error-title {
-  color: $red;
   font-size: 12vw;
+  color: $red;
   margin-bottom: .75rem;
   text-align: center;
 }

--- a/assets/components/pages/event-list/event-list.scss
+++ b/assets/components/pages/event-list/event-list.scss
@@ -1,5 +1,5 @@
 .events-filters {
-  
+
   form {
     display: flex;
     flex-wrap: wrap;
@@ -21,42 +21,41 @@
       padding-right: 10px;
     }
   }
-  
+
   .select-multiple .ms-drop,
   .select-multiple .ms-drop ul,
   .dropdown .picker__table{
     width: auto;
   }
-  
+
   .dropdown {
     margin-bottom: 1rem;
-    
+
     button {
       display: flex;
+      width: 100%;
+      padding: $custom-select-padding-y $custom-select-padding-x;
       justify-content: space-between;
       align-items: center;
-      padding: $custom-select-padding-y $custom-select-padding-x;
       text-align: left;
-      width: 100%;
     }
-    
+
     .dropdown-menu.show {
-      left: auto !important;
-      right: 0;
-      transform: none !important;
       top: 38px !important;
+      right: 0;
+      left: auto !important;
+      transform: none !important;
     }
-    
+
     .picker__holder {
       border: 0;
     }
   }
-  
+
   @include media-breakpoint-down(md) {
-    
+
     .dropdown {
       flex-basis: 100%;
     }
   }
 }
-

--- a/assets/config/helpers.scss
+++ b/assets/config/helpers.scss
@@ -52,7 +52,6 @@
   }
 }
 
-//
 // Display helpers
 .flex-grow {
   flex: 1 1 auto;
@@ -71,7 +70,6 @@
   overflow: hidden;
 }
 
-//
 // Text helpers
 .text-small {
   font-size: $font-size-xs;

--- a/assets/config/layout.scss
+++ b/assets/config/layout.scss
@@ -3,19 +3,19 @@
 
 // Retrieve content coloumn width
 @function col-width($breakpoint, $columns) {
-  @return map-get($container-max-widths, $breakpoint)  * math.div($columns, $grid-columns);
+  @return map-get($container-max-widths, $breakpoint) * math.div($columns, $grid-columns);
 }
 
-//
-// GRID MANAGEMENT
-//
-// Wrap everything in this class (must be taking the full viewport width) to enable
-// CSS Grid for immediate children.
-//
-// All items that must not take the "content" area into account have the class
-// "container-full". Inside those items, use a regular Bootstrap layout as you
-// would in a normal setup.
-//
+/*
+ * GRID MANAGEMENT
+ *
+ * Wrap everything in this class (must be taking the full viewport width) to enable
+ * CSS Grid for immediate children.
+ *
+ * All items that must not take the "content" area into account have the class
+ * "container-full". Inside those items, use a regular Bootstrap layout as you
+ * would in a normal setup.
+ */
 
 .container-grid {
   display: grid;

--- a/assets/config/layout.scss
+++ b/assets/config/layout.scss
@@ -6,16 +6,15 @@
   @return map-get($container-max-widths, $breakpoint) * math.div($columns, $grid-columns);
 }
 
-/*
- * GRID MANAGEMENT
- *
- * Wrap everything in this class (must be taking the full viewport width) to enable
- * CSS Grid for immediate children.
- *
- * All items that must not take the "content" area into account have the class
- * "container-full". Inside those items, use a regular Bootstrap layout as you
- * would in a normal setup.
- */
+// GRID MANAGEMENT
+
+// Wrap everything in this class (must be taking the full viewport width) to enable
+// CSS Grid for immediate children.
+
+// All items that must not take the "content" area into account have the class
+// "container-full". Inside those items, use a regular Bootstrap layout as you
+// would in a normal setup.
+
 
 .container-grid {
   display: grid;

--- a/assets/config/variables.scss
+++ b/assets/config/variables.scss
@@ -1,6 +1,7 @@
 @charset 'utf-8';
 
-@import "./social-color.scss";
+@use 'sass:map';
+@import "./social-color";
 
 /*
   Variables for trapezes card
@@ -17,7 +18,7 @@ $mm-lang-height: 3rem;
 $mm-lang-width: 5.8rem;
 
 $opacities: () !default;
-$opacities: map-merge((
+$opacities: map.merge((
   "0": 0,
   "10": .1,
   "20": .2,

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     ],
     "extends": "stylelint-config-recommended-scss",
     "rules": {
+      "scss/at-extend-no-missing-placeholder": null,
       "at-rule-no-vendor-prefix": true,
       "media-feature-name-no-vendor-prefix": true,
       "property-no-vendor-prefix": true,


### PR DESCRIPTION
```bash
./node_modules/.bin/stylelint "assets/**/*.scss"

assets/components/entrypoint.scss
  11:61  ✖  Unexpected extension ".scss" in @import  scss/at-import-partial-extension
  14:17  ✖  Unexpected extension ".scss" in @import  scss/at-import-partial-extension
  19:1   ✖  Unexpected empty comment                 scss/comment-no-empty
  50:1   ✖  Unexpected empty comment                 scss/comment-no-empty
 102:1   ✖  Unexpected empty comment                 scss/comment-no-empty
 126:1   ✖  Unexpected empty comment                 scss/comment-no-empty

assets/config/helpers.scss
 55:1  ✖  Unexpected empty comment  scss/comment-no-empty
 74:1  ✖  Unexpected empty comment  scss/comment-no-empty

assets/config/layout.scss
  6:56  ✖  Expected single space before "*"                                           scss/operator-no-unspaced
  9:1   ✖  Unexpected empty comment                                                   scss/comment-no-empty
 11:1   ✖  Unexpected empty comment                                                   scss/comment-no-empty
 14:1   ✖  Unexpected empty comment                                                   scss/comment-no-empty
 18:1   ✖  Unexpected empty comment                                                   scss/comment-no-empty
 76:5   ✖  Expected a placeholder selector (e.g. %placeholder) to be used in @extend  scss/at-extend-no-missing-placeholder

assets/config/variables.scss
  3:25  ✖  Unexpected extension ".scss" in @import  scss/at-import-partial-extension
 20:13  ✖  Expected map.merge instead of map-merge  scss/no-global-function-names

assets/components/atoms/alert/alert.scss
 33:28  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color, $amount)  scss/no-global-function-names
 34:26  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color, $amount)  scss/no-global-function-names

assets/components/atoms/button/button.scss
 11:3   ✖  Expected a placeholder selector (e.g. %placeholder) to be used in @extend            scss/at-extend-no-missing-placeholder
 35:17  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color,        scss/no-global-function-names
           $amount)
 36:19  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color,        scss/no-global-function-names
           $amount)

assets/components/atoms/collapse/collapse.scss
  42:3   ✖  Expected "position" to come before "color"     order/properties-order
  97:4   ✖  Expected single colon pseudo-element notation  selector-pseudo-element-colon-notation
 139:4   ✖  Expected single colon pseudo-element notation  selector-pseudo-element-colon-notation
 275:17  ✖  Expected single space before "*"               scss/operator-no-unspaced
 275:17  ✖  Expected single space after "*"                scss/operator-no-unspaced

assets/components/atoms/link/link.scss
 40:3  ✖  Expected a placeholder selector (e.g. %placeholder) to be used in @extend  scss/at-extend-no-missing-placeholder

assets/components/atoms/list/list.scss
 102:7  ✖  Expected "top" to come before "border"  order/properties-order

assets/components/atoms/popover/popover.scss
 68:14  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color, $amount)  scss/no-global-function-names

assets/components/atoms/range/range.scss
 16:46  ✖  Expected single space before "/"  scss/operator-no-unspaced
 16:46  ✖  Expected single space after "/"   scss/operator-no-unspaced

assets/components/atoms/select/select.scss
 59:7  ✖  Expected "font-size" to come before "color"  order/properties-order

assets/components/atoms/tag/tag.scss
   6:23  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color,       scss/no-global-function-names
            $amount)
   7:25  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color,       scss/no-global-function-names
            $amount)
   8:24  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color,       scss/no-global-function-names
            $amount)
  72:15  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color,       scss/no-global-function-names
            $amount)
  93:17  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color,       scss/no-global-function-names
            $amount)
 103:5   ✖  Expected a placeholder selector (e.g. %placeholder) to be used in @extend           scss/at-extend-no-missing-placeholder
 117:27  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color,       scss/no-global-function-names
            $amount)
 118:29  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color,       scss/no-global-function-names
            $amount)
 119:28  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color,       scss/no-global-function-names
            $amount)
 157:27  ✖  Expected color.adjust($color, $lightness: $amount) instead of lighten($color,       scss/no-global-function-names
            $amount)

assets/components/content-types/coursebook/coursebook.scss
 92:3  ✖  Expected a placeholder selector (e.g. %placeholder) to be used in @extend  scss/at-extend-no-missing-placeholder

assets/components/content-types/event/event.scss
 74:5  ✖  Expected "height" to come before "background"  order/properties-order

assets/components/content-types/study-plan/study-plan.scss
 335:27  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color, $amount)  scss/no-global-function-names
 349:3   ✖  Unexpected empty comment                                                                scss/comment-no-empty

assets/components/molecules/card/card.scss
   4:1  ✖  Unexpected empty comment                                            scss/comment-no-empty
  82:1  ✖  Unexpected empty comment                                            scss/comment-no-empty
 100:1  ✖  Unexpected empty comment                                            scss/comment-no-empty
 163:1  ✖  Unexpected duplicate selector ".card-info", first used at line 102  no-duplicate-selectors
 185:7  ✖  Expected "height" to come before "color"                            order/properties-order
 186:7  ✖  Expected "width" to come before "height"                            order/properties-order
 195:1  ✖  Unexpected empty comment                                            scss/comment-no-empty
 231:1  ✖  Unexpected empty comment                                            scss/comment-no-empty
 257:1  ✖  Unexpected empty comment                                            scss/comment-no-empty
 282:1  ✖  Unexpected empty comment                                            scss/comment-no-empty

assets/components/molecules/footnotes/footnotes.scss
 109:15  ✖  Expected color.adjust($color, $alpha: -$amount) instead of transparentize($color, $amount)  scss/no-global-function-names

assets/components/molecules/form-group/form-group.scss
 31:5  ✖  Expected "position" to come before "color"  order/properties-order

assets/components/molecules/tabs/tabs.scss
 44:25  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color, $amount)  scss/no-global-function-names
 57:57  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color, $amount)  scss/no-global-function-names
 61:25  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color, $amount)  scss/no-global-function-names

assets/components/organisms/fullwidth-teaser/fullwidth-teaser.scss
  94:14  ✖  Expected map.get instead of map-get                                                     scss/no-global-function-names
 175:19  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color, $amount)  scss/no-global-function-names
 185:27  ✖  Expected color.adjust($color, $lightness: -$amount) instead of darken($color, $amount)  scss/no-global-function-names

assets/components/organisms/header/header.scss
 160:5  ✖  Expected "line-height" to come before "font-weight"  order/properties-order

assets/components/organisms/nav-main/nav-main.scss
   5:1   ✖  Unexpected empty comment          scss/comment-no-empty
   7:1   ✖  Unexpected empty comment          scss/comment-no-empty
 137:42  ✖  Expected single space before "+"  scss/operator-no-unspaced
 137:42  ✖  Expected single space after "+"   scss/operator-no-unspaced
 139:19  ✖  Expected single space before "*"  scss/operator-no-unspaced
 178:1   ✖  Unexpected empty comment          scss/comment-no-empty
 181:1   ✖  Unexpected empty comment          scss/comment-no-empty
 210:1   ✖  Unexpected empty comment          scss/comment-no-empty
 212:1   ✖  Unexpected empty comment          scss/comment-no-empty
 287:1   ✖  Unexpected empty comment          scss/comment-no-empty
 289:1   ✖  Unexpected empty comment          scss/comment-no-empty
 363:1   ✖  Unexpected empty comment          scss/comment-no-empty
 365:1   ✖  Unexpected empty comment          scss/comment-no-empty

assets/components/organisms/restauration/restauration.scss
 21:7  ✖  Expected a placeholder selector (e.g. %placeholder) to be used in @extend  scss/at-extend-no-missing-placeholder

assets/components/pages/error-404/error-404.scss
 4:3  ✖  Expected "font-size" to come before "color"  order/properties-order

assets/components/pages/event-list/event-list.scss
 40:7  ✖  Expected "width" to come before "padding"  order/properties-order
 45:7  ✖  Expected "right" to come before "left"     order/properties-order
 47:7  ✖  Expected "top" to come before "transform"  order/properties-order

83 problems (83 errors, 0 warnings)
```