### PR TITLE
Mise à jour du content-type "event"

### DIFF
--- a/assets/components/content-types/event/event-listing-featured.twig
+++ b/assets/components/content-types/event/event-listing-featured.twig
@@ -1,5 +1,5 @@
 <div class="list-group list-events list-events-featured">
-  {% include '@molecules/card/card-event.twig' %}
-  {% include '@molecules/card/card-event.twig' with { eventLocation: 'online_room', live_now: true, online_event: true } %}
-  {% include '@molecules/card/card-event.twig' with { eventLocation: 'online', online_event: true } %}
+  {% include '@molecules/list-group/list-group-event.twig' %}
+  {% include '@molecules/list-group/list-group-event.twig' with { eventLocation: 'online_room', live_now: true, online_event: true } %}
+  {% include '@molecules/list-group/list-group-event.twig' with { eventLocation: 'online', online_event: true } %}
 </div>

--- a/assets/components/content-types/event/event-listing.twig
+++ b/assets/components/content-types/event/event-listing.twig
@@ -1,11 +1,11 @@
 <div class="list-group list-events {% if hasGrayBackground|default(false) %}list-group-gray{% endif %}">
 
-  {% include '@molecules/card/card-event.twig' with { eventLocation: 'online_room', live_now: true } %}
+  {% include '@molecules/list-group/list-group-event.twig' with { eventLocation: 'online_room', live_now: true } %}
 
-  {% include '@molecules/card/card-event.twig' with { eventLocation: 'online' } %}
+  {% include '@molecules/list-group/list-group-event.twig' with { eventLocation: 'online' } %}
 
   {% for i in 1..3 %}
-    {% include '@molecules/card/card-event.twig' %}
+    {% include '@molecules/list-group/list-group-event.twig' %}
   {% endfor %}
 
   {% if bottomlink|default(true) %}

--- a/assets/components/content-types/event/event.scss
+++ b/assets/components/content-types/event/event.scss
@@ -20,6 +20,12 @@
   }
 }
 
+.event-info {
+  p {
+    margin-bottom: 0;
+  }
+}
+
 // List
 
 .list-events {

--- a/assets/components/content-types/event/event.twig
+++ b/assets/components/content-types/event/event.twig
@@ -10,24 +10,54 @@
     {% block summary %}{% endblock -%}
     <div class="card-info">
       {% block date %}
-      <span class="card-info-date" itemprop="startDate" content="2018-01-10T12:00">10.01.2018</span>
-      <span>13:00</span>
-      <span>17:30</span>
-      {% endblock %}
-      <p>
-      <span itemprop="performer" itemscope itemtype="http://schema.org/performer">
-      {% block speaker %}
-        Avec <b>Prof. Dr. Aditya Mueller</b>
-      {% endblock %}
-      </span>
-      <span itemprop="location" itemscope itemtype="http://schema.org/Place">
-      <br>
-        {% block info %}
-        Lieu : <b><span itemprop="name">ArtLab EPFL</span></b>
-        <br> Catégorie : <b>Événements culturel</b>
-        {% endblock %}
-      </span>
+      <p class="event-info-date mb-1">
+        {% include '@atoms/icon/icon.twig' with { icon:  'calendar', icon_classes:'feather' } %}
+        <span class="sr-only">Dates: du</span>
+        <span class="card-info-date event-date" itemprop="startDate" content="2018-01-10T12:00">10.01.2018</span>
+        <span class="sep" aria-hidden="true">›</span>
+        <span class="sr-only">au</span>
+        <span class="card-info-date event-date" itemprop="endDate" content="2018-01-12T12:00">12.01.2018</span>
+        {% include '@atoms/icon/icon.twig' with { icon:  'clock', icon_classes:'feather' } %}
+        <span class="sr-only">Heures: de</span>
+        <span class="event-time">13:00</span>
+        <span class="sep" aria-hidden="true">›</span>
+        <span class="sr-only">à</span>
+        <span class="event-time">17:30</span>
       </p>
+      {% endblock %}
+      <div class="event-info mt-1">
+        {% block speaker %}
+        <p class="event-speaker" itemprop="performer" itemscope itemtype="http://schema.org/performer">
+          <b>Intervenant·e:</b> Prof. Dr. Aditya Mueller
+        </p>  
+        {% endblock %}
+        {% block location %}
+        <p class="event-location" itemprop="location" itemscope itemtype="http://schema.org/Place">
+          {% if eventLocation == 'online' %}
+          <b>Lieu:</b> {% include '@atoms/icon/icon.twig' with { icon: 'monitor', icon_classes:'feather' } %}
+          <span itemprop="name">En ligne</span>
+          {% elseif eventLocation == 'online_room' %}
+          <b>Lieu:</b> {% include '@atoms/icon/icon.twig' with { icon: 'map-pin', icon_classes:'feather' } %}
+          <span itemprop="name">ArtLab EPFL</span> &amp;
+          {% include '@atoms/icon/icon.twig' with { icon: 'monitor', icon_classes:'feather' } %}
+          <span itemprop="name">En ligne</span>
+          {% else %}
+          <b>Lieu:</b> {% include '@atoms/icon/icon.twig' with { icon: 'map-pin', icon_classes:'feather' } %}
+          <span itemprop="name">ArtLab EPFL</span>
+          {% endif %}
+        </p>
+        {% endblock %}
+        {% block category %}
+        <p class="event-category">
+          <b>Catégorie:</b> Événements culturel
+        </p>
+        {% endblock %}
+        {% block audience %}
+        <p class="event-audience" itemprop="audience" itemscope itemtype="https://schema.org/audience">
+          <b>Public cible:</b> Tout public
+        </p>
+        {% endblock %}
+      </div>
     </div>
   </div>
   {% block footer %}{% endblock %}

--- a/assets/components/molecules/list-group/list-group-event.twig
+++ b/assets/components/molecules/list-group/list-group-event.twig
@@ -24,13 +24,13 @@
           <span class="event-time">17:30</span>
         </p>
         {% endblock %}
-        <p class="event-info mt-1">
-          <span class="event-speaker" itemprop="performer" itemscope itemtype="http://schema.org/performer">
+        <div class="event-info mt-1">
+          <p class="event-speaker" itemprop="performer" itemscope itemtype="http://schema.org/performer">
           {% block speaker %}
             <b>Intervenant·e:</b> Prof. Dr. Aditya Mueller
           {% endblock %}
-          </span>            
-          <span class="event-location" itemprop="location" itemscope itemtype="http://schema.org/Place">
+          </p>            
+          <p class="event-location" itemprop="location" itemscope itemtype="http://schema.org/Place">
           {% block location %}
             
             {% if eventLocation == 'online' %}
@@ -47,18 +47,18 @@
             {% endif %}
             
           {% endblock %}
-          </span>
-          <span class="event-category">
+          </p>
+          <p class="event-category">
           {% block category %}
             <b>Catégorie:</b> Événements culturel
           {% endblock %}
-          </span>
-          <span class="event-audience" itemprop="audience" itemscope itemtype="https://schema.org/audience">
+          </p>
+          <p class="event-audience" itemprop="audience" itemscope itemtype="https://schema.org/audience">
           {% block audience %}
             <b>Public cible:</b> Tout public
           {% endblock %}
-          </span>
-        </p>
+          </p>
+        </div>
         
         <p class="pt-3 event-actions">
           {% if live_now|default(false) %}

--- a/assets/components/molecules/list-group/list-group-event.twig
+++ b/assets/components/molecules/list-group/list-group-event.twig
@@ -1,4 +1,4 @@
-<div href="#" class="list-group-item list-group-teaser" itemscope itemtype="http://schema.org/Event">
+<div class="list-group-item list-group-teaser" itemscope itemtype="http://schema.org/Event">
   <div class="list-group-teaser-container">
     <div class="list-group-teaser-thumbnail">
       {% include '@atoms/picture/picture.twig' with {'variant':'news-thumb'} %}
@@ -22,8 +22,8 @@
           <span class="sep" aria-hidden="true">›</span>
           <span class="sr-only">à</span>
           <span class="event-time">17:30</span>
-          {% endblock %}
         </p>
+        {% endblock %}
         <p class="event-info mt-1">
           <span class="event-speaker" itemprop="performer" itemscope itemtype="http://schema.org/performer">
           {% block speaker %}

--- a/assets/components/molecules/list-group/list-group-event.twig
+++ b/assets/components/molecules/list-group/list-group-event.twig
@@ -25,14 +25,13 @@
         </p>
         {% endblock %}
         <div class="event-info mt-1">
-          <p class="event-speaker" itemprop="performer" itemscope itemtype="http://schema.org/performer">
           {% block speaker %}
+          <p class="event-speaker" itemprop="performer" itemscope itemtype="http://schema.org/performer">
             <b>Intervenant·e:</b> Prof. Dr. Aditya Mueller
+          </p>  
           {% endblock %}
-          </p>            
-          <p class="event-location" itemprop="location" itemscope itemtype="http://schema.org/Place">
           {% block location %}
-            
+          <p class="event-location" itemprop="location" itemscope itemtype="http://schema.org/Place">
             {% if eventLocation == 'online' %}
             <b>Lieu:</b> {% include '@atoms/icon/icon.twig' with { icon: 'monitor', icon_classes:'feather' } %}
             <span itemprop="name"><a href="#">En ligne</a></span>
@@ -45,19 +44,18 @@
             <b>Lieu:</b> {% include '@atoms/icon/icon.twig' with { icon: 'map-pin', icon_classes:'feather' } %}
             <span itemprop="name"><a href="#">ArtLab EPFL</a></span>
             {% endif %}
-            
-          {% endblock %}
           </p>
-          <p class="event-category">
+          {% endblock %}
           {% block category %}
+          <p class="event-category">
             <b>Catégorie:</b> Événements culturel
-          {% endblock %}
           </p>
-          <p class="event-audience" itemprop="audience" itemscope itemtype="https://schema.org/audience">
+          {% endblock %}
           {% block audience %}
+          <p class="event-audience" itemprop="audience" itemscope itemtype="https://schema.org/audience">
             <b>Public cible:</b> Tout public
-          {% endblock %}
           </p>
+          {% endblock %}
         </div>
         
         <p class="pt-3 event-actions">

--- a/assets/components/pages/event-list/event-list.twig
+++ b/assets/components/pages/event-list/event-list.twig
@@ -149,13 +149,13 @@
   </div>
   
   <div class="list-group list-events mt-4">
-    {% include '@molecules/card/card-event.twig' with { eventLocation: 'online_room', live_now: true } %}
-    {% include '@molecules/card/card-event.twig' with { eventLocation: 'online', live_now: true } %}
+    {% include '@molecules/list-group/list-group-event.twig' with { eventLocation: 'online_room', live_now: true } %}
+    {% include '@molecules/list-group/list-group-event.twig' with { eventLocation: 'online', live_now: true } %}
     {% for i in 1..2 %}
-      {% include '@molecules/card/card-event.twig' with { eventLocation: 'online' } %}
+      {% include '@molecules/list-group/list-group-event.twig' with { eventLocation: 'online' } %}
     {% endfor %}
     {% for i in 1..6 %}
-      {% include '@molecules/card/card-event.twig' %}
+      {% include '@molecules/list-group/list-group-event.twig' %}
     {% endfor %}
   </div>
   


### PR DESCRIPTION
https://epfl-webvolution.atlassian.net/browse/WEBEVOL-226

La molécule "card/card-event" devient "list-group/list-group-event" (c'était une erreur de ma part au départ, le HTML est celui d'un list-group, pas d'une card). J'en ai profité pour faire une petite modification de HTML, mais ça ne change rien visuellement si l'ancien markup est conservé.

J'ai mis à jour le content type Event / Basic teaser, le changement est automatiquement appliqué aux variantes Highlight, Just finished et Slider Wrapper.