### PR TITLE
Width grid-template in lg breakpoint

### DIFF
--- a/assets/config/layout.scss
+++ b/assets/config/layout.scss
@@ -42,7 +42,7 @@
   @include media-breakpoint-up(lg) {
     grid-template-columns:
       [full-start] 1fr
-      [content-start] #{col-width(lg, 8)}
+      [content-start] #{col-width(lg, 7.125)}
       [content-end] 1fr
       [full-end];
   }


### PR DESCRIPTION
Dans les écrans entre 992 et 1200px (iPad pro par exemple), la largeur de _grid-column > content-width_ (les textes, par exemple) est plus grande que celle dans les écrans de plus grande taille.

Pour une largeur standard de 570px, nous sautons à 640px.
Le nombre de caractères par ligne passe des 70 recommandés à plus de 80 caractères par ligne.