### PR TITLE
[fix] `:last-child` doesn't want parentheses

### DIFF
--- a/assets/components/molecules/tables/tables.scss
+++ b/assets/components/molecules/tables/tables.scss
@@ -19,7 +19,7 @@
       border-bottom: 1px solid $gray-200;
 
       @include media-breakpoint-down(sm) {
-        &:last-child() {
+        &:last-child {
           margin-bottom: 1.2rem;
         }
       }


### PR DESCRIPTION
Source: https://developer.mozilla.org/fr/docs/Web/CSS/:last-child + whining from esbuild.

Fixes #700
