### PR TITLE
[fix] Restrict `tag` class scope

### DIFF
--- a/assets/components/atoms/tag/tag.scss
+++ b/assets/components/atoms/tag/tag.scss
@@ -12,7 +12,7 @@ a.tag {
   }
 }
 
-a.tag, button.tag, span.tag {
+a.tag, button.tag, span.tag, div.tag, p.tag {
   display: inline-block;
   margin: 0 0.1em 0.3em 0;
   padding: 0.4em 0.6em;

--- a/assets/components/atoms/tag/tag.scss
+++ b/assets/components/atoms/tag/tag.scss
@@ -12,7 +12,7 @@ a.tag {
   }
 }
 
-.tag {
+a.tag, button.tag, span.tag {
   display: inline-block;
   margin: 0 0.1em 0.3em 0;
   padding: 0.4em 0.6em;


### PR DESCRIPTION
This fixes a CSS clash since `class="tag"` is not exactly rare, as seen for instance on the screenshot below (for Storybook).