### PR TITLE
Give item preview full height space

### DIFF
--- a/reader/reader.scss
+++ b/reader/reader.scss
@@ -41,9 +41,11 @@
   overflow: hidden;
 }
 
-/*  Dropdown needs `overflow: visible` to allow it to
+/*  Dropdown and multi select needs `overflow: visible` to allow it to
     escape its container. */
-.tlbx-item-preview.tlbx-component-dropdown {
+.tlbx-item-preview.tlbx-element-dropdown,
+.tlbx-item-preview.tlbx-element-select-multiple,
+.tlbx-item-preview.tlbx-element-breadcrumb-dropdown {
   overflow: visible;
 }
 

--- a/reader/views/Single/Single.scss
+++ b/reader/views/Single/Single.scss
@@ -6,12 +6,9 @@
 }
 
 .tlbx-single-full {
-  display: flex;
-  flex-direction: column;
   min-height: 100vh;
 
   .tlbx-item-preview {
-    flex-grow: 1;
     border: 0;
   }
 

--- a/reader/views/Single/Single.scss
+++ b/reader/views/Single/Single.scss
@@ -6,9 +6,12 @@
 }
 
 .tlbx-single-full {
+  display: flex;
+  flex-direction: column;
   min-height: 100vh;
 
   .tlbx-item-preview {
+    flex-grow: 1;
     border: 0;
   }
 


### PR DESCRIPTION
Une petite proposition d'amélioration pour l'affichage "full render". Actuellement, la hauteur de <div class="tlbx-item-preview">, qui contient l'exemple de composant, s'adapte à la hauteur du composant. S'il contient un élément qui déborde, comme un dropdown, celui-ci n'est pas visible. Grâce à flexbox, on peut forcer le container à occuper tout l'espace disponible dans la fenêtre.