### PR TITLE
Styleguide: mise à jour du breadcrumb et de la navigation mobile

### DIFF
--- a/assets/components/entrypoint.scss
+++ b/assets/components/entrypoint.scss
@@ -83,6 +83,7 @@
 @import 'organisms/fullwidth-teaser/fullwidth-teaser';
 @import 'organisms/nav-main/nav-main';
 @import 'organisms/nav-aside/nav-aside';
+@import 'organisms/nav-mobile/nav-mobile';
 @import 'organisms/contact/contact';
 @import 'organisms/footer/footer';
 @import 'organisms/form/form';

--- a/assets/components/molecules/breadcrumb/breadcrumb-dropdown.twig
+++ b/assets/components/molecules/breadcrumb/breadcrumb-dropdown.twig
@@ -5,6 +5,12 @@
         {% include '@atoms/icon/icon.twig' with { icon: 'icon-home' } %}
       </a>
     </li>
+    <li class="breadcrumb-item expand-links">
+      <button class="btn btn-expand-links" aria-expanded="false" title="Display the complete path">
+        <span class="dots" aria-hidden="true">…</span>
+        <span class="sr-only">Display the complete path</span>
+      </button>
+    </li>
     <li class="breadcrumb-item">
       <a class="bread-link" href="#">Schools</a>
       <div class="dropdown">

--- a/assets/components/molecules/breadcrumb/breadcrumb-dropdown.twig
+++ b/assets/components/molecules/breadcrumb/breadcrumb-dropdown.twig
@@ -1,0 +1,19 @@
+<nav aria-label="breadcrumb" class="breadcrumb-wrapper">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item">
+      <a class="bread-link bread-home" href="#">
+        {% include '@atoms/icon/icon.twig' with { icon: 'icon-home' } %}
+      </a>
+    </li>
+    <li class="breadcrumb-item">
+      <a class="bread-link" href="#">Schools</a>
+    </li>
+    <li class="breadcrumb-item">
+      <a class="bread-link" href="#">School of Architecture, Civil and Environmental Engineering</a>
+    </li>
+    <li class="breadcrumb-item">
+      <a class="bread-link" href="#">Sustainability challenges</a>
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">FUSTIC association</li>
+  </ol>
+</nav>

--- a/assets/components/molecules/breadcrumb/breadcrumb-dropdown.twig
+++ b/assets/components/molecules/breadcrumb/breadcrumb-dropdown.twig
@@ -7,13 +7,57 @@
     </li>
     <li class="breadcrumb-item">
       <a class="bread-link" href="#">Schools</a>
+      <div class="dropdown">
+        <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="dropdown-menu-1">
+          {% include '@atoms/icon/icon.twig' with { icon: 'arrow-down-circle', icon_classes:'feather' } %}
+          <span class="sr-only">Display same level pages – Schools</span>
+        </button>
+        <ul class="dropdown-menu" id="dropdown-menu-1">
+          <li class="dropdown-item"><a href="#">About</a></li>
+          <li class="dropdown-item"><a href="#">Education</a></li>
+          <li class="dropdown-item"><a href="#">Research</a></li>
+          <li class="dropdown-item"><a href="#">Innovation</a></li>
+          <li class="dropdown-item current-menu-item-parent"><a href="#">Schools</a></li>
+          <li class="dropdown-item"><a href="#">Campus</a></li>
+        </ul>
+      </div>
     </li>
     <li class="breadcrumb-item">
       <a class="bread-link" href="#">School of Architecture, Civil and Environmental Engineering</a>
+      <div class="dropdown">
+        <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="dropdown-menu-2">
+          {% include '@atoms/icon/icon.twig' with { icon: 'arrow-down-circle', icon_classes:'feather' } %}
+          <span class="sr-only">Display same level pages – School of Architecture, Civil and Environmental Engineering</span>
+        </button>
+        <ul class="dropdown-menu" id="dropdown-menu-2">
+          <li class="dropdown-item current-menu-item-parent"><a href="#">School of Architecture, Civil and Environmental Engineering</a></li>
+          <li class="dropdown-item"><a href="#">School of Computer and Communication Sciences</a></li>
+          <li class="dropdown-item"><a href="#">School of Basic Sciences</a></li>
+          <li class="dropdown-item"><a href="#">School of Engineering</a></li>
+          <li class="dropdown-item"><a href="#">School of Life Sciences</a></li>
+          <li class="dropdown-item"><a href="#">College of Management of Technology</a></li>
+          <li class="dropdown-item"><a href="#">College of Humanities</a></li>
+          <li class="dropdown-item"><a href="#">Sections</a></li>
+        </ul>
+      </div>
     </li>
     <li class="breadcrumb-item">
       <a class="bread-link" href="#">Sustainability challenges</a>
     </li>
-    <li class="breadcrumb-item active" aria-current="page">FUSTIC association</li>
+    <li class="breadcrumb-item active" aria-current="page">
+      <span class="bread-item">FUSTIC association</span>
+      <div class="dropdown">
+        <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="dropdown-menu-3">
+          {% include '@atoms/icon/icon.twig' with { icon: 'arrow-down-circle', icon_classes:'feather' } %}
+          <span class="sr-only">Display same level pages – FUSTIC association</span>
+        </button>
+        <ul class="dropdown-menu" id="dropdown-menu-3">
+          <li class="dropdown-item"><a href="#">ENAC Clusters</a></li>
+          <li class="dropdown-item"><a href="#">Interdisciplinary Centers</a></li>
+          <li class="dropdown-item current-menu-item-parent"><a href="#">FUSTIC association</a></li>
+          <li class="dropdown-item"><a href="#">Sustainability grants</a></li>
+        </ul>
+      </div>
+    </li>
   </ol>
 </nav>

--- a/assets/components/molecules/breadcrumb/breadcrumb-tagged.twig
+++ b/assets/components/molecules/breadcrumb/breadcrumb-tagged.twig
@@ -16,9 +16,58 @@
         <span class="sr-only">Display the complete path</span>
       </button>
     </li>
-    <li class="breadcrumb-item"><a href="#">Schools</a></li>
-    <li class="breadcrumb-item"><a href="#">ENAC</a></li>
-    <li class="breadcrumb-item"><a href="#">Formations</a></li>
-    <li class="breadcrumb-item active" aria-current="page">Projets</li>
+    <li class="breadcrumb-item">
+      <a class="bread-link" href="#">Schools</a>
+      <div class="dropdown">
+        <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="dropdown-menu-1">
+          {% include '@atoms/icon/icon.twig' with { icon: 'arrow-down-circle', icon_classes:'feather' } %}
+          <span class="sr-only">Display same level pages – Schools</span>
+        </button>
+        <ul class="dropdown-menu" id="dropdown-menu-1">
+          <li class="dropdown-item"><a href="#">About</a></li>
+          <li class="dropdown-item"><a href="#">Education</a></li>
+          <li class="dropdown-item"><a href="#">Research</a></li>
+          <li class="dropdown-item"><a href="#">Innovation</a></li>
+          <li class="dropdown-item current-menu-item-parent"><a href="#">Schools</a></li>
+          <li class="dropdown-item"><a href="#">Campus</a></li>
+        </ul>
+      </div>
+    </li>
+    <li class="breadcrumb-item">
+      <a class="bread-link" href="#">School of Architecture, Civil and Environmental Engineering</a>
+      <div class="dropdown">
+        <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="dropdown-menu-2">
+          {% include '@atoms/icon/icon.twig' with { icon: 'arrow-down-circle', icon_classes:'feather' } %}
+          <span class="sr-only">Display same level pages – School of Architecture, Civil and Environmental Engineering</span>
+        </button>
+        <ul class="dropdown-menu" id="dropdown-menu-2">
+          <li class="dropdown-item current-menu-item-parent"><a href="#">School of Architecture, Civil and Environmental Engineering</a></li>
+          <li class="dropdown-item"><a href="#">School of Computer and Communication Sciences</a></li>
+          <li class="dropdown-item"><a href="#">School of Basic Sciences</a></li>
+          <li class="dropdown-item"><a href="#">School of Engineering</a></li>
+          <li class="dropdown-item"><a href="#">School of Life Sciences</a></li>
+          <li class="dropdown-item"><a href="#">College of Management of Technology</a></li>
+          <li class="dropdown-item"><a href="#">College of Humanities</a></li>
+          <li class="dropdown-item"><a href="#">Sections</a></li>
+        </ul>
+      </div>
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">
+      <span class="bread-item">ENAC Faculty</span>
+      <div class="dropdown">
+        <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="dropdown-menu-3">
+          {% include '@atoms/icon/icon.twig' with { icon: 'arrow-down-circle', icon_classes:'feather' } %}
+          <span class="sr-only">Display same level pages – ENAC Faculty</span>
+        </button>
+        <ul class="dropdown-menu" id="dropdown-menu-3">
+          <li class="dropdown-item"><a href="#">News</a></li>
+          <li class="dropdown-item current-menu-item-parent"><a href="#">ENAC Faculty</a></li>
+          <li class="dropdown-item"><a href="#">Education</a></li>
+          <li class="dropdown-item"><a href="#">Research</a></li>
+          <li class="dropdown-item"><a href="#">Sustainability challenges</a></li>
+          <li class="dropdown-item"><a href="#">Intranet ENAC</a></li>
+        </ul>
+      </div>
+    </li>
   </ol>
 </nav>

--- a/assets/components/molecules/breadcrumb/breadcrumb-tagged.twig
+++ b/assets/components/molecules/breadcrumb/breadcrumb-tagged.twig
@@ -10,6 +10,12 @@
       <a href="#" class="tag tag-primary">Innovation</a>
       <a href="#" class="tag tag-primary">W3C</a>
     </li>
+    <li class="breadcrumb-item expand-links">
+      <button class="btn btn-expand-links" aria-expanded="false" title="Display the complete path">
+        <span class="dots" aria-hidden="true">…</span>
+        <span class="sr-only">Display the complete path</span>
+      </button>
+    </li>
     <li class="breadcrumb-item"><a href="#">Schools</a></li>
     <li class="breadcrumb-item"><a href="#">ENAC</a></li>
     <li class="breadcrumb-item"><a href="#">Formations</a></li>

--- a/assets/components/molecules/breadcrumb/breadcrumb.js
+++ b/assets/components/molecules/breadcrumb/breadcrumb.js
@@ -2,8 +2,26 @@
 
 export default () => {
   const expandBreadcrumb = $('.btn-expand-links');
+  const breadcrumbDropToggle = $('.dropdown-toggle');
 
+  // add class 'has-expanded-links'
   expandBreadcrumb.click(function(){
     $(".breadcrumb-wrapper .breadcrumb").addClass("has-expanded-links");
+  });
+
+  // improve dropdown position
+  breadcrumbDropToggle.click(function(){
+    var btnPos = $(this).offset().left;
+    var documentWitdh = $(document).width();
+    var dropdown = $(this).siblings(".dropdown-menu");
+    var dropdownWidth = dropdown.width();
+    var btnOffset = documentWitdh - btnPos;
+
+    // remove class 'open-left' from all .dropdown-menu elements
+    $(".dropdown-menu").removeClass("open-left");
+    // add the class back if the dropdown is too close to the right side of the window
+    if ( dropdownWidth > btnOffset ) {
+      dropdown.addClass("open-left");
+    }
   });
 };

--- a/assets/components/molecules/breadcrumb/breadcrumb.js
+++ b/assets/components/molecules/breadcrumb/breadcrumb.js
@@ -1,59 +1,9 @@
 /* globals $ */
 
 export default () => {
-  //const breadcrumb = $('#breadcrumb-wrapper');
   const expandBreadcrumb = $('.btn-expand-links');
 
   expandBreadcrumb.click(function(){
     $(".breadcrumb-wrapper .breadcrumb").addClass("has-expanded-links");
   });
-
-
-  /*
-  if ($(breadcrumb).length > 0) {  // don't expect to have the breadcrumb on every case
-    const breadcrumbNode = breadcrumb[0];
-    const breadcrumbComponent = breadcrumb.find('.breadcrumb');
-
-    if ($(window).width() > 1199 &&
-        $(breadcrumbComponent).length > 0 &&  // don't expect to have the breadcrumbComponent on every case
-        breadcrumb.width() < breadcrumbComponent[0].scrollWidth) {
-      let isDown = false;
-      let startX;
-      let scrollLeft;
-
-      breadcrumb.on('mousedown', (e) => {
-        isDown = true;
-        breadcrumb.addClass('moving');
-        startX = e.pageX - breadcrumbNode.offsetLeft;
-        // eslint-disable-next-line
-        scrollLeft = breadcrumbNode.scrollLeft;
-      });
-
-      breadcrumb.on('mouseleave', () => {
-        isDown = false;
-        breadcrumb.removeClass('moving');
-      });
-
-      breadcrumb.on('mouseup', () => {
-        isDown = false;
-        breadcrumb.removeClass('moving');
-      });
-
-      breadcrumb.on('mousemove', (e) => {
-        if (!isDown) return; // stop the fn from running
-        e.preventDefault();
-        const x = e.pageX - breadcrumbNode.offsetLeft;
-        const walk = (x - startX) * 3;
-        breadcrumbNode.scrollLeft = scrollLeft - walk;
-      });
-
-      breadcrumb.mousewheel((e, delta) => {
-        e.preventDefault();
-        breadcrumbNode.scrollLeft -= delta * 40;
-      });
-
-      breadcrumb.find('*').on('dragstart', () => false);
-    }
-  }
-  */
 };

--- a/assets/components/molecules/breadcrumb/breadcrumb.js
+++ b/assets/components/molecules/breadcrumb/breadcrumb.js
@@ -5,23 +5,23 @@ export default () => {
   const breadcrumbDropToggle = $('.dropdown-toggle');
 
   // add class 'has-expanded-links'
-  expandBreadcrumb.click(function(){
-    $(".breadcrumb-wrapper .breadcrumb").addClass("has-expanded-links");
+  expandBreadcrumb.on('click', () => {
+    $('.breadcrumb-wrapper .breadcrumb').addClass('has-expanded-links');
   });
 
   // improve dropdown position
-  breadcrumbDropToggle.click(function(){
-    var btnPos = $(this).offset().left;
-    var documentWitdh = $(document).width();
-    var dropdown = $(this).siblings(".dropdown-menu");
-    var dropdownWidth = dropdown.width();
-    var btnOffset = documentWitdh - btnPos;
+  breadcrumbDropToggle.on('click', (e) => {
+    const btnPos = $(e.currentTarget).offset().left;
+    const documentWitdh = $(document).width();
+    const dropdown = $(e.currentTarget).siblings('.dropdown-menu');
+    const dropdownWidth = dropdown.width();
+    const btnOffset = documentWitdh - btnPos;
 
     // remove class 'open-left' from all .dropdown-menu elements
-    $(".dropdown-menu").removeClass("open-left");
+    $('.dropdown-menu').removeClass('open-left');
     // add the class back if the dropdown is too close to the right side of the window
-    if ( dropdownWidth > btnOffset ) {
-      dropdown.addClass("open-left");
+    if (dropdownWidth > btnOffset) {
+      dropdown.addClass('open-left');
     }
   });
 };

--- a/assets/components/molecules/breadcrumb/breadcrumb.js
+++ b/assets/components/molecules/breadcrumb/breadcrumb.js
@@ -1,8 +1,15 @@
 /* globals $ */
 
 export default () => {
-  const breadcrumb = $('#breadcrumb-wrapper');
+  //const breadcrumb = $('#breadcrumb-wrapper');
+  const expandBreadcrumb = $('.btn-expand-links');
 
+  expandBreadcrumb.click(function(){
+    $(".breadcrumb-wrapper .breadcrumb").addClass("has-expanded-links");
+  });
+
+
+  /*
   if ($(breadcrumb).length > 0) {  // don't expect to have the breadcrumb on every case
     const breadcrumbNode = breadcrumb[0];
     const breadcrumbComponent = breadcrumb.find('.breadcrumb');
@@ -48,4 +55,5 @@ export default () => {
       breadcrumb.find('*').on('dragstart', () => false);
     }
   }
+  */
 };

--- a/assets/components/molecules/breadcrumb/breadcrumb.scss
+++ b/assets/components/molecules/breadcrumb/breadcrumb.scss
@@ -168,6 +168,7 @@
   .breadcrumb .breadcrumb-item.expand-links,
   .breadcrumb .breadcrumb-item:last-of-type,
   .breadcrumb .breadcrumb-item.active,
+  .breadcrumb .breadcrumb-item.breadcrumb-tags-wrapper,
   .breadcrumb.has-expanded-links .breadcrumb-item {
     display: inline;
   }

--- a/assets/components/molecules/breadcrumb/breadcrumb.scss
+++ b/assets/components/molecules/breadcrumb/breadcrumb.scss
@@ -33,13 +33,10 @@
 .breadcrumb-wrapper {
   max-width: 100%;
   width: 100%;
-  //min-height: 2.15rem;
   border-bottom: 1px solid gray('200');
 
   @include media-breakpoint-up(lg) {
-    overflow-x: auto;
     overflow-y: visible;
-    //white-space: nowrap;
     user-select: none;
   }
 }
@@ -82,7 +79,7 @@
 }
 
 .breadcrumb-item {
-  display: inline-block;
+  display: inline;
   position: relative;
   font-size: $font-size-sm;
   line-height: 1.5rem;
@@ -93,13 +90,7 @@
 
   @include media-breakpoint-down(sm) {
 
-    &:not(.breadcrumb-tags-wrapper) {
-      display: none;
-    }
 
-    &.breadcrumb-tags-wrapper:after {
-      display: none;
-    }
   }
 
   &:before {
@@ -120,9 +111,9 @@
   }
 
   &:after {
-    content: '\203A';
-    padding-left: 0.3rem;
-    color: $gray-700;
+    content: "/";
+    color: $gray-500;
+    padding-inline: 0.25rem;
   }
 
   a {
@@ -150,6 +141,80 @@
 
   &.active {
     color: $gray-700;
+    font-weight: bold;
+  }
+}
+
+// Dropdown
+
+.breadcrumb .dropdown {
+  display: inline;
+  position: static;
+}
+
+.breadcrumb .dropdown-toggle {
+  border: 0;
+  border-radius: 50%;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  height: 1.25rem;
+  margin-left: 0;
+  width: 1.25rem;
+  top: -0.08em;
+
+  .icon {
+    color: currentColor;
+    font-size: 1rem;
+    top: 0;
+    transition: all 0.2s ease-in-out;
+    transform: rotate(0);
+  }
+
+  &:after {
+    content: none;
+  }
+
+  &:hover,
+  &:active {
+    background: $red !important;
+    color: $white !important;
+  }
+
+  &:focus,
+  &:focus-visible {
+    outline-offset: 0;
+  }
+
+  &:focus:not(:focus-visible) {
+    outline-color: transparent !important;
+  }
+
+  &[aria-expanded="true"] .icon {
+    transform: rotate(180deg);
+  }
+}
+
+.breadcrumb .dropdown-menu {
+  &.show {
+    // dropdown position depends on the <li>, not the button
+    left: -0.625rem !important;
+    top: 2rem !important;
+    transform: none !important;
+  }
+}
+
+.breadcrumb .dropdown-item {
+  font-size: 0.83rem;
+  padding: 0.125em 0.625rem;
+
+  a {
+    display: block;
+  }
+
+  &.current-menu-item,
+  &.current-menu-item-parent {
     font-weight: bold;
   }
 }

--- a/assets/components/molecules/breadcrumb/breadcrumb.scss
+++ b/assets/components/molecules/breadcrumb/breadcrumb.scss
@@ -139,8 +139,8 @@
   }
 
   &.active {
-    color: $gray-700;
     font-weight: bold;
+    color: $gray-700;
   }
 
   &.expand-links {
@@ -151,10 +151,10 @@
 // Expand links button
 
 .breadcrumb .btn-expand-links {
-  padding: 0;
-  font-size: inherit;
-  border: 0;
   height: auto;
+  padding: 0;
+  border: 0;
+  font-size: inherit;
   line-height: 1;
 }
 

--- a/assets/components/molecules/breadcrumb/breadcrumb.scss
+++ b/assets/components/molecules/breadcrumb/breadcrumb.scss
@@ -5,17 +5,6 @@
   position: relative;
   margin-bottom: $spacer * 1.6;
 
-  &:before {
-    content: ' ';
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: $spacer * 3;
-    height: calc(100% - 2px);
-    background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, $white 80%, $white 100%);
-    z-index: $zindex-breadcrumbs + 10;
-  }
-
   @include media-breakpoint-down(lg) {
     //height: $mm-breadcrumbs-height;
     padding: 0 ($spacer * 0.8);

--- a/assets/components/molecules/breadcrumb/breadcrumb.scss
+++ b/assets/components/molecules/breadcrumb/breadcrumb.scss
@@ -77,10 +77,6 @@
     display: inline;
   }
 
-  @include media-breakpoint-down(md) {
-    display: inline;
-  }
-
   &:before {
     content: ' ';
     display: block;
@@ -159,7 +155,7 @@
   .breadcrumb .breadcrumb-item.active,
   .breadcrumb .breadcrumb-item.breadcrumb-tags-wrapper,
   .breadcrumb.has-expanded-links .breadcrumb-item {
-    display: inline;
+    display: inline-block;
   }
 }
 
@@ -217,9 +213,14 @@
 .breadcrumb .dropdown-menu {
   &.show {
     // dropdown position depends on the <li>, not the button
-    top: 2rem !important;
+    top: 1.65rem !important;
     left: -0.625rem !important;
     transform: none !important;
+
+    &.open-left {
+      left: auto !important;
+      right: -0.625rem !important;
+    }
   }
 }
 

--- a/assets/components/molecules/breadcrumb/breadcrumb.scss
+++ b/assets/components/molecules/breadcrumb/breadcrumb.scss
@@ -134,7 +134,7 @@
       color: $black;
     }
   }
-  
+
   .tag {
     vertical-align: baseline;
   }
@@ -150,5 +150,6 @@
 
   &.active {
     color: $gray-700;
+    font-weight: bold;
   }
 }

--- a/assets/components/molecules/breadcrumb/breadcrumb.scss
+++ b/assets/components/molecules/breadcrumb/breadcrumb.scss
@@ -79,7 +79,7 @@
 }
 
 .breadcrumb-item {
-  display: inline;
+  display: inline-block;
   position: relative;
   font-size: $font-size-sm;
   line-height: 1.5rem;
@@ -88,9 +88,8 @@
     display: inline;
   }
 
-  @include media-breakpoint-down(sm) {
-
-
+  @include media-breakpoint-down(md) {
+    display: inline;
   }
 
   &:before {
@@ -142,6 +141,35 @@
   &.active {
     color: $gray-700;
     font-weight: bold;
+  }
+
+  &.expand-links {
+    display: none;
+  }
+}
+
+// Expand links button
+
+.breadcrumb .btn-expand-links {
+  padding: 0;
+  font-size: inherit;
+  border: 0;
+  height: auto;
+  line-height: 1;
+}
+
+@include media-breakpoint-down(md) {
+  .breadcrumb .breadcrumb-item,
+  .breadcrumb.has-expanded-links .breadcrumb-item.expand-links {
+    display: none;
+  }
+
+  .breadcrumb .breadcrumb-item:first-of-type,
+  .breadcrumb .breadcrumb-item.expand-links,
+  .breadcrumb .breadcrumb-item:last-of-type,
+  .breadcrumb .breadcrumb-item.active,
+  .breadcrumb.has-expanded-links .breadcrumb-item {
+    display: inline;
   }
 }
 
@@ -216,5 +244,9 @@
   &.current-menu-item,
   &.current-menu-item-parent {
     font-weight: bold;
+  }
+
+  @include media-breakpoint-down(md) {
+    white-space: normal;
   }
 }

--- a/assets/components/molecules/breadcrumb/breadcrumb.scss
+++ b/assets/components/molecules/breadcrumb/breadcrumb.scss
@@ -218,8 +218,8 @@
     transform: none !important;
 
     &.open-left {
-      left: auto !important;
       right: -0.625rem !important;
+      left: auto !important;
     }
   }
 }

--- a/assets/components/molecules/breadcrumb/breadcrumb.scss
+++ b/assets/components/molecules/breadcrumb/breadcrumb.scss
@@ -181,23 +181,23 @@
 }
 
 .breadcrumb .dropdown-toggle {
-  border: 0;
-  border-radius: 50%;
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  padding: 0;
+  top: -0.08em;
+  width: 1.25rem;
   height: 1.25rem;
   margin-left: 0;
-  width: 1.25rem;
-  top: -0.08em;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
 
   .icon {
-    color: currentColor;
-    font-size: 1rem;
     top: 0;
-    transition: all 0.2s ease-in-out;
+    font-size: 1rem;
+    color: currentColor;
     transform: rotate(0);
+    transition: all 0.2s ease-in-out;
   }
 
   &:after {
@@ -227,15 +227,15 @@
 .breadcrumb .dropdown-menu {
   &.show {
     // dropdown position depends on the <li>, not the button
-    left: -0.625rem !important;
     top: 2rem !important;
+    left: -0.625rem !important;
     transform: none !important;
   }
 }
 
 .breadcrumb .dropdown-item {
-  font-size: 0.83rem;
   padding: 0.125em 0.625rem;
+  font-size: 0.83rem;
 
   a {
     display: block;

--- a/assets/components/molecules/breadcrumb/breadcrumb.twig
+++ b/assets/components/molecules/breadcrumb/breadcrumb.twig
@@ -5,6 +5,12 @@
         {% include '@atoms/icon/icon.twig' with { icon: 'icon-home' } %}
       </a>
     </li>
+    <li class="breadcrumb-item expand-links">
+      <button class="btn btn-expand-links" aria-expanded="false" title="Display the complete path">
+        <span class="dots" aria-hidden="true">…</span>
+        <span class="sr-only">Display the complete path</span>
+      </button>
+    </li>
     <li class="breadcrumb-item"><a class="bread-link" href="#">Schools</a></li>
     <li class="breadcrumb-item active" aria-current="page">ENAC</li>
   </ol>

--- a/assets/components/molecules/breadcrumb/breadcrumb.twig
+++ b/assets/components/molecules/breadcrumb/breadcrumb.twig
@@ -1,11 +1,11 @@
 <nav aria-label="breadcrumb" class="breadcrumb-wrapper">
   <ol class="breadcrumb">
     <li class="breadcrumb-item">
-      <a href="#">
+      <a class="bread-link bread-home" href="#">
         {% include '@atoms/icon/icon.twig' with { icon: 'icon-home' } %}
       </a>
     </li>
-    <li class="breadcrumb-item"><a href="#">Schools</a></li>
+    <li class="breadcrumb-item"><a class="bread-link" href="#">Schools</a></li>
     <li class="breadcrumb-item active" aria-current="page">ENAC</li>
   </ol>
 </nav>

--- a/assets/components/molecules/breadcrumb/breadcrumb.yml
+++ b/assets/components/molecules/breadcrumb/breadcrumb.yml
@@ -7,3 +7,5 @@ variants:
     title: Tagged
   - name: dropdown
     title: Dropdown
+    notes: |
+      Breadcrumb dropdowns are used to display same level pages.

--- a/assets/components/molecules/breadcrumb/breadcrumb.yml
+++ b/assets/components/molecules/breadcrumb/breadcrumb.yml
@@ -3,9 +3,9 @@ name: breadcrumb
 notes: |
   The breadcrumb is your compass, on every page. It helps you to understand where you are, so you can decide where to go next.
 variants:
-  - name: tagged
-    title: Tagged
   - name: dropdown
     title: Dropdown
     notes: |
       Breadcrumb dropdowns are used to display same level pages.
+  - name: tagged
+    title: Tagged

--- a/assets/components/molecules/breadcrumb/breadcrumb.yml
+++ b/assets/components/molecules/breadcrumb/breadcrumb.yml
@@ -5,3 +5,5 @@ notes: |
 variants:
   - name: tagged
     title: Tagged
+  - name: dropdown
+    title: Dropdown

--- a/assets/components/organisms/nav-aside/nav-aside.scss
+++ b/assets/components/organisms/nav-aside/nav-aside.scss
@@ -25,6 +25,24 @@
 .nav-aside-layout .nav-aside-wrapper {
   display: block;
 
+  @include media-breakpoint-down(lg) {
+    padding: 1rem;
+
+    .nav-aside {
+      [class^="h"] {
+        padding: 0;
+      }
+      a {
+        padding-inline: 1rem;
+        font-size: 1rem;
+      }
+    }
+  }
+
+  @include media-breakpoint-up(xl) {
+    height: 100%;
+  }
+
   @include media-breakpoint-up(xxl){
     flex: 0 0 16.1%;
     max-width: 16.1%;

--- a/assets/components/organisms/nav-aside/nav-aside.scss
+++ b/assets/components/organisms/nav-aside/nav-aside.scss
@@ -67,7 +67,7 @@
     }
 
     &.active:not(.menu-item-has-children)+li>a:before {
-      content: none;
+      //content: none;
     }
 
     @include media-breakpoint-down(lg) {

--- a/assets/components/organisms/nav-aside/nav-aside.scss
+++ b/assets/components/organisms/nav-aside/nav-aside.scss
@@ -33,7 +33,7 @@
         padding: 0;
       }
       a {
-        padding-inline: 1rem;
+        padding-inline: 1.5rem;
         font-size: 1rem;
       }
     }
@@ -84,12 +84,10 @@
       &:before { content: none; }
     }
 
-    &.active:not(.menu-item-has-children)+li>a:before {
-      //content: none;
-    }
-
     @include media-breakpoint-down(lg) {
-      &.active > a { margin-right: $spacer * 2; }
+      &.active > a {
+        margin-inline: 0;
+      }
     }
   }
   & > ul > li:first-child > a:before { content: none; }

--- a/assets/components/organisms/nav-aside/nav-aside.twig
+++ b/assets/components/organisms/nav-aside/nav-aside.twig
@@ -5,7 +5,7 @@
   aria-describedby="nav-aside-title"
 >
   <h2 class="h5 sr-only-xl" id="nav-aside-title">Dans la même section</h2>
-  <ul>
+  <ul class="nav-menu">
   {% if nav_aside_items %}
     {% for item in nav_aside_items %}
     {% if item.siblings_before and loop.index0 == nav_aside_active %}

--- a/assets/components/organisms/nav-aside/nav-aside.twig
+++ b/assets/components/organisms/nav-aside/nav-aside.twig
@@ -4,10 +4,15 @@
   role="navigation"
   aria-describedby="nav-aside-title"
 >
-  <h2 class="h5 sr-only-xl">Dans la même section</h2>
+  <h2 class="h5 sr-only-xl" id="nav-aside-title">Dans la même section</h2>
   <ul>
   {% if nav_aside_items %}
     {% for item in nav_aside_items %}
+    {% if item.siblings_before and loop.index0 == nav_aside_active %}
+      {% for child in item.siblings_before %}
+      <li><a href="#">{{child}}</a></li>
+      {% endfor %}
+    {% endif %}
     <li{% if loop.index0 == nav_aside_active %} class="active"{% endif %}>
       <a href="#">
         {{item.label}}
@@ -23,6 +28,11 @@
       </ul>
       {% endif %}
     </li>
+    {% if item.siblings_after and loop.index0 == nav_aside_active %}
+      {% for child in item.siblings_after %}
+      <li><a href="#">{{child}}</a></li>
+      {% endfor %}
+    {% endif %}
     {% endfor %}
   {% else %}
     <li><a href="#">S'inscrire au Master</a></li>

--- a/assets/components/organisms/nav-aside/nav-aside.yml
+++ b/assets/components/organisms/nav-aside/nav-aside.yml
@@ -1,2 +1,6 @@
 title: Nav aside
 name: nav-aside
+notes: |
+  **Mobile version**
+
+  On small devices, the side navigation can be displayed inside the mobile navigation, below the main menu. See [Nav Mobile](/#/organisms/nav-mobile)

--- a/assets/components/organisms/nav-mobile/nav-mobile.scss
+++ b/assets/components/organisms/nav-mobile/nav-mobile.scss
@@ -1,16 +1,16 @@
 
 .nav-toggle-layout > .nav-container {
+  width: auto;
   margin: 0;
   padding: 0;
-  width: auto;
 
   @include media-breakpoint-down(lg) {
-    background: #fff;
     position: absolute;
     top: 0;
     bottom: 0;
     left: 0;
     width: 100%;
+    background: #fff;
     border-top: 1px solid #c1c1c1;
     overflow-y: scroll;
     transform: translateX(-100%);
@@ -24,8 +24,8 @@
 }
 
 .nav-main-mobile {
-  border: 0;
   position: static;
+  border: 0;
   transform: none !important;
 
   @include media-breakpoint-up(xl) {
@@ -42,12 +42,12 @@
   }
 
   .nav-container .nav-menu {
-    border-bottom: 1px solid $gray-300;
     display: grid;
     grid-template-columns: repeat(3,1fr);
-    padding-block: 1rem;
     position: static;
     width: 100%;
+    padding-block: 1rem;
+    border-bottom: 1px solid $gray-300;
 
     li {
       border: 0;

--- a/assets/components/organisms/nav-mobile/nav-mobile.scss
+++ b/assets/components/organisms/nav-mobile/nav-mobile.scss
@@ -64,11 +64,3 @@
     }
   }
 }
-
-.nav-aside-layout .nav-aside-wrapper {
-  @include media-breakpoint-up(xl) {
-    height: 100%;
-  }
-}
-
-

--- a/assets/components/organisms/nav-mobile/nav-mobile.scss
+++ b/assets/components/organisms/nav-mobile/nav-mobile.scss
@@ -1,0 +1,67 @@
+
+.nav-toggle-layout > .nav-container {
+  margin: 0;
+  padding: 0;
+  width: auto;
+
+  @include media-breakpoint-down(lg) {
+    background: #fff;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    border-top: 1px solid #c1c1c1;
+    overflow-y: scroll;
+    transform: translateX(-100%);
+    transition: transform 0.2s;
+    z-index: 120;
+
+    .mobile-menu-open & {
+      transform: translateX(0);
+    }
+  }
+}
+
+.nav-main-mobile {
+  border: 0;
+  position: static;
+  transform: none !important;
+
+  @include media-breakpoint-up(xl) {
+   display: none;
+  }
+
+  .nav-wrapper {
+    height: auto;
+  }
+
+  .nav-container {
+    margin-left: 0;
+    padding-left: 0;
+  }
+
+  .nav-container .nav-menu {
+    border-bottom: 1px solid $gray-300;
+    display: grid;
+    grid-template-columns: repeat(3,1fr);
+    padding-block: 1rem;
+    position: static;
+    width: 100%;
+
+    li {
+      border: 0;
+    }
+
+    li a {
+      margin-block: 0;
+      padding-block: 0.4 * $spacer;
+    }
+
+    li.current-menu-item > a:first-child {
+      background: transparent;
+      color: $black;
+    }
+  }
+}
+

--- a/assets/components/organisms/nav-mobile/nav-mobile.scss
+++ b/assets/components/organisms/nav-mobile/nav-mobile.scss
@@ -65,3 +65,10 @@
   }
 }
 
+.nav-aside-layout .nav-aside-wrapper {
+  @include media-breakpoint-up(xl) {
+    height: 100%;
+  }
+}
+
+

--- a/assets/components/organisms/nav-mobile/nav-mobile.twig
+++ b/assets/components/organisms/nav-mobile/nav-mobile.twig
@@ -13,4 +13,12 @@
       </div>
     </div>
   </nav>
+  <!-- Add side navigation here in order to display it in the mobile menu -->
+  {% if not isSpecial %}
+  <aside class="nav-aside-wrapper">
+    {% block sideNav %}
+      {% include '@organisms/nav-aside/nav-aside.twig' %}
+    {% endblock %}
+  </aside>
+  {% endif %}
 </div>

--- a/assets/components/organisms/nav-mobile/nav-mobile.twig
+++ b/assets/components/organisms/nav-mobile/nav-mobile.twig
@@ -1,0 +1,16 @@
+<div class="nav-container">
+  <nav class="nav-main nav-main-mobile" id="main-navigation" role="navigation">
+    <div class="nav-wrapper">
+      <div class="nav-container current-menu-parent">
+        <ul id="menu-main" class="nav-menu">
+          <li class=""><a href="#">About</a></li>
+          <li><a href="#">Education</a></li>
+          <li><a href="#">Research</a></li>
+          <li><a href="#">Innovation</a></li>
+          <li class="current-menu-item"><a href="#">Schools</a></li>
+          <li><a href="#">Campus</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+</div>

--- a/assets/components/organisms/nav-mobile/nav-mobile.yml
+++ b/assets/components/organisms/nav-mobile/nav-mobile.yml
@@ -1,0 +1,5 @@
+title: Nav mobile
+name: nav-mobile
+wrapper: nav-toggle-layout
+notes: |
+  The mobile navigation is opened by clicking the [Nav Toggle Button](/#/atoms/nav-toggle-mobile).

--- a/assets/components/pages/about/about.twig
+++ b/assets/components/pages/about/about.twig
@@ -1,3 +1,5 @@
+{% set isSpecial = true %}
+
 {% extends "@templates/base/base.twig" %}
 
 {% block content %}

--- a/assets/components/pages/association-list/association-list.twig
+++ b/assets/components/pages/association-list/association-list.twig
@@ -1,3 +1,5 @@
+{% set isSpecial = true %}
+
 {% extends "@templates/base/base.twig" %}
 
 {% block content %}

--- a/assets/components/pages/lab-homepage/lab-homepage.twig
+++ b/assets/components/pages/lab-homepage/lab-homepage.twig
@@ -1,3 +1,5 @@
+{% set hasTaggedBreadcrumb = true %}
+
 {% extends "@templates/base/base.twig" %}
 
 {% block header %}

--- a/assets/components/pages/lab-homepage/lab-homepage.twig
+++ b/assets/components/pages/lab-homepage/lab-homepage.twig
@@ -5,8 +5,10 @@
 {% endblock %}
 
 {% set nav_aside_items = [{
-  label: "Laboratory Full Name",
-  children: ["Projects", "Publications", "News", "Team", "Teaching"]
+  label: "ENAC Faculty",
+  siblings_before:  ["News"],
+  siblings_after:  ["Education", "Research", "Sustainability challenges", "Intranet ENAC"],
+  children: ["Organization", "Projects", "Publications", "Team", "Teaching"]
 }] %}
 {% set nav_aside_active = 0 %}
 

--- a/assets/components/pages/study-plan-course/study-plan-course.twig
+++ b/assets/components/pages/study-plan-course/study-plan-course.twig
@@ -43,7 +43,7 @@
           </button>
           <ul class="dropdown-menu" id="dropdown-menu-1">
             <li class="dropdown-item"><a href="#">À propos</a></li>
-            <li class="dropdown-item" current-menu-item-parent"><a href="#">Éducation</a></li>
+            <li class="dropdown-item current-menu-item-parent"><a href="#">Éducation</a></li>
             <li class="dropdown-item"><a href="#">Recherche</a></li>
             <li class="dropdown-item"><a href="#">Innovation</a></li>
             <li class="dropdown-item"><a href="#">Facultés</a></li>

--- a/assets/components/pages/study-plan-course/study-plan-course.twig
+++ b/assets/components/pages/study-plan-course/study-plan-course.twig
@@ -24,14 +24,36 @@
   <nav aria-label="breadcrumb" class="breadcrumb-wrapper">
     <ol class="breadcrumb">
       <li class="breadcrumb-item">
-        <a href="#">
+        <a class="bread-link bread-home" href="#">
           {% include '@atoms/icon/icon.twig' with { icon: 'icon-home' } %}
         </a>
       </li>
-      <li class="breadcrumb-item"><a href="#">Éducation</a></li>
-      <li class="breadcrumb-item"><a href="#">Plans d'études</a></li>
-      <li class="breadcrumb-item"><a href="#">Cycle Bachelor</a></li>
-      <li class="breadcrumb-item"><a href="#">Architecture</a></li>
+      <li class="breadcrumb-item expand-links">
+        <button class="btn btn-expand-links" aria-expanded="false" title="Afficher le chemin complet">
+          <span class="dots" aria-hidden="true">…</span>
+          <span class="sr-only">Afficher le chemin complet</span>
+        </button>
+      </li>
+      <li class="breadcrumb-item">
+        <a class="bread-link" href="#">Éducation</a>
+        <div class="dropdown">
+          <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="dropdown-menu-1">
+            {% include '@atoms/icon/icon.twig' with { icon: 'arrow-down-circle', icon_classes:'feather' } %}
+            <span class="sr-only">Afficher les pages de même niveau – Éducation</span>
+          </button>
+          <ul class="dropdown-menu" id="dropdown-menu-1">
+            <li class="dropdown-item"><a href="#">À propos</a></li>
+            <li class="dropdown-item" current-menu-item-parent"><a href="#">Éducation</a></li>
+            <li class="dropdown-item"><a href="#">Recherche</a></li>
+            <li class="dropdown-item"><a href="#">Innovation</a></li>
+            <li class="dropdown-item"><a href="#">Facultés</a></li>
+            <li class="dropdown-item"><a href="#">Campus</a></li>
+          </ul>
+        </div>
+      </li>
+      <li class="breadcrumb-item"><a class="bread-link" href="#">Plans d'études</a></li>
+      <li class="breadcrumb-item"><a class="bread-link" href="#">Cycle Bachelor</a></li>
+      <li class="breadcrumb-item"><a class="bread-link" href="#">Architecture</a></li>
       <li class="breadcrumb-item active" aria-current="page">Art et architecture</li>
     </ol>
   </nav>

--- a/assets/components/pages/study-plan/study-plan.twig
+++ b/assets/components/pages/study-plan/study-plan.twig
@@ -42,7 +42,7 @@
           </button>
           <ul class="dropdown-menu" id="dropdown-menu-1">
             <li class="dropdown-item"><a href="#">À propos</a></li>
-            <li class="dropdown-item" current-menu-item-parent"><a href="#">Éducation</a></li>
+            <li class="dropdown-item current-menu-item-parent"><a href="#">Éducation</a></li>
             <li class="dropdown-item"><a href="#">Recherche</a></li>
             <li class="dropdown-item"><a href="#">Innovation</a></li>
             <li class="dropdown-item"><a href="#">Facultés</a></li>

--- a/assets/components/pages/study-plan/study-plan.twig
+++ b/assets/components/pages/study-plan/study-plan.twig
@@ -23,12 +23,34 @@
   <nav aria-label="breadcrumb" class="breadcrumb-wrapper">
     <ol class="breadcrumb">
       <li class="breadcrumb-item">
-        <a href="#">
+        <a class="bread-link bread-home" href="#">
           {% include '@atoms/icon/icon.twig' with { icon: 'icon-home' } %}
         </a>
       </li>
-      <li class="breadcrumb-item"><a href="#">Éducation</a></li>
-      <li class="breadcrumb-item"><a href="#">Plans d'études</a></li>
+      <li class="breadcrumb-item expand-links">
+        <button class="btn btn-expand-links" aria-expanded="false" title="Afficher le chemin complet">
+          <span class="dots" aria-hidden="true">…</span>
+          <span class="sr-only">Afficher le chemin complet</span>
+        </button>
+      </li>
+      <li class="breadcrumb-item">
+        <a class="bread-link" href="#">Éducation</a>
+        <div class="dropdown">
+          <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="dropdown-menu-1">
+            {% include '@atoms/icon/icon.twig' with { icon: 'arrow-down-circle', icon_classes:'feather' } %}
+            <span class="sr-only">Afficher les pages de même niveau – Éducation</span>
+          </button>
+          <ul class="dropdown-menu" id="dropdown-menu-1">
+            <li class="dropdown-item"><a href="#">À propos</a></li>
+            <li class="dropdown-item" current-menu-item-parent"><a href="#">Éducation</a></li>
+            <li class="dropdown-item"><a href="#">Recherche</a></li>
+            <li class="dropdown-item"><a href="#">Innovation</a></li>
+            <li class="dropdown-item"><a href="#">Facultés</a></li>
+            <li class="dropdown-item"><a href="#">Campus</a></li>
+          </ul>
+        </div>
+      </li>
+      <li class="breadcrumb-item"><a class="bread-link" href="#">Plans d'études</a></li>
       <li class="breadcrumb-item active" aria-current="page">Cycle Bachelor</li>
     </ol>
   </nav>

--- a/assets/components/templates/base/base.twig
+++ b/assets/components/templates/base/base.twig
@@ -19,7 +19,7 @@
   <div{% if not isSpecial %} class="nav-toggle-layout nav-aside-layout"{% endif %}>
 
     {% block nav %}
-      {% include '@organisms/nav-main/nav-main.twig' %}
+      {% include '@organisms/nav-mobile/nav-mobile.twig' %}
     {% endblock %}
 
     <div class="w-100 pb-5">

--- a/assets/components/templates/base/base.twig
+++ b/assets/components/templates/base/base.twig
@@ -11,7 +11,6 @@
   {% block breadcrumb %}
     {% if not isSpecial %}
     <div class="breadcrumb-container">
-      <div>{% include '@atoms/nav-toggle/nav-toggle.twig' %}</div>
       {% include '@molecules/breadcrumb/breadcrumb-tagged.twig' %}
     </div>
     {% endif %}

--- a/assets/components/templates/base/base.twig
+++ b/assets/components/templates/base/base.twig
@@ -11,7 +11,11 @@
   {% block breadcrumb %}
     {% if not isSpecial %}
     <div class="breadcrumb-container">
-      {% include '@molecules/breadcrumb/breadcrumb-tagged.twig' %}
+      {% if hasTaggedBreadcrumb %}
+       {% include '@molecules/breadcrumb/breadcrumb-tagged.twig' %}
+      {% else %}
+       {% include '@molecules/breadcrumb/breadcrumb-dropdown.twig' %}
+      {% endif %}
     </div>
     {% endif %}
   {% endblock %}

--- a/assets/components/templates/base/base.twig
+++ b/assets/components/templates/base/base.twig
@@ -16,7 +16,7 @@
     {% endif %}
   {% endblock %}
 
-  <div{% if not isSpecial %} class="nav-toggle-layout nav-aside-layout"{% endif %}>
+  <div class="nav-toggle-layout{% if not isSpecial %} nav-aside-layout{% endif %}">
 
     {% block nav %}
       {% include '@organisms/nav-mobile/nav-mobile.twig' %}
@@ -31,14 +31,6 @@
       {% endblock %}
 
     </div>
-
-    {% if not isSpecial %}
-    <aside class="nav-aside-wrapper">
-      {% block sideNav %}
-        {% include '@organisms/nav-aside/nav-aside.twig' %}
-      {% endblock %}
-    </aside>
-    {% endif %}
   </div>
 
   {% block footer_container %}


### PR DESCRIPTION
**Breadcrumb**
- Ajout des dropdowns qui contiennent les pages de même niveau;
- Sur desktop: toutes les étapes sont affichées, si nécessaire le breadcrumb passe sur plusieurs lignes;
- Sur mobile / tablette: par défaut, uniquement la maison et la dernière étape sont affichées. Entre deux se trouve un bouton avec trois petit points; lorsqu'on clique dessus, le chemin entier est affiché (sur plusieurs lignes si nécessaire).

**Navigation mobile**
Le menu mobile comprend désormais deux navigations:
- Le menu principal, affiché de manière plus simple, sur deux lignes;
- La navigation latérale (nav aside) qui contient les pages de même niveau que la page courante, ainsi que ses pages enfants.

Pour un exemple complet du breadcrumb et de la navigation mobile, voir le modèle de page **Lab Homepage**.