### PR TITLE
Fix social icon size in footer light

### DIFF
--- a/assets/components/organisms/footer/footer-light.scss
+++ b/assets/components/organisms/footer/footer-light.scss
@@ -20,7 +20,7 @@
   border-top: 1px solid $gray-100;
 
   .social-icon-negative .icon {
-    font-size: 1.35rem;
+    font-size: 1.375rem;
   }
 }
 


### PR DESCRIPTION
In the footer light, pixels are missing on the right for the Instagram or LinkedIn icons depending on the case.

| Before | After |
|----------|----------|
| ![Screenshot from 2024-05-23 14-19-53](https://github.com/epfl-si/elements/assets/2843501/7d859dfe-ac77-4cb0-8909-66f0b0069885) |![Screenshot from 2024-05-23 14-29-10](https://github.com/epfl-si/elements/assets/2843501/215dd264-2b10-4185-8f38-f001b332c245) | 
|![Screenshot from 2024-05-23 14-19-31](https://github.com/epfl-si/elements/assets/2843501/251af99d-780c-4437-b7fc-3301a523acac) |  ![Screenshot from 2024-05-23 14-17-35](https://github.com/epfl-si/elements/assets/2843501/4f6b1095-5c26-43ab-a4bc-73691c40288f)  | 