### PR TITLE
Améliorations visuelles du breadcrumb dropdown

### DIFF
--- a/assets/components/molecules/breadcrumb/breadcrumb-dropdown.twig
+++ b/assets/components/molecules/breadcrumb/breadcrumb-dropdown.twig
@@ -29,14 +29,14 @@
       </div>
     </li>
     <li class="breadcrumb-item">
-      <a class="bread-link" href="#">School of Architecture, Civil and Environmental Engineering</a>
+      <a class="bread-link" href="#">ENAC</a>
       <div class="dropdown">
         <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="dropdown-menu-2">
           {% include '@atoms/icon/icon.twig' with { icon: 'arrow-down-circle', icon_classes:'feather' } %}
-          <span class="sr-only">Display same level pages – School of Architecture, Civil and Environmental Engineering</span>
+          <span class="sr-only">Display same level pages – ENAC</span>
         </button>
         <ul class="dropdown-menu" id="dropdown-menu-2">
-          <li class="dropdown-item current-menu-item-parent"><a href="#">School of Architecture, Civil and Environmental Engineering</a></li>
+          <li class="dropdown-item current-menu-item-parent"><a href="#">School of Architecture, Civil and Environmental Engineering (ENAC)</a></li>
           <li class="dropdown-item"><a href="#">School of Computer and Communication Sciences</a></li>
           <li class="dropdown-item"><a href="#">School of Basic Sciences</a></li>
           <li class="dropdown-item"><a href="#">School of Engineering</a></li>

--- a/assets/components/molecules/breadcrumb/breadcrumb.scss
+++ b/assets/components/molecules/breadcrumb/breadcrumb.scss
@@ -211,6 +211,8 @@
 }
 
 .breadcrumb .dropdown-menu {
+  min-width: 11.5rem;
+
   &.show {
     // dropdown position depends on the <li>, not the button
     top: 1.65rem !important;

--- a/assets/components/molecules/breadcrumb/breadcrumb.scss
+++ b/assets/components/molecules/breadcrumb/breadcrumb.scss
@@ -227,9 +227,14 @@
 .breadcrumb .dropdown-item {
   padding: 0.125em 0.625rem;
   font-size: 0.83rem;
+  line-height: 1.3em;
 
   a {
     display: block;
+  }
+
+  & + .dropdown-item {
+    margin-top: 0.5rem;
   }
 
   &.current-menu-item,

--- a/assets/components/molecules/breadcrumb/breadcrumb.scss
+++ b/assets/components/molecules/breadcrumb/breadcrumb.scss
@@ -62,7 +62,7 @@
     }
 
     li:last-child {
-      padding-right: 5rem;
+      margin-right: 5rem;
     }
   }
 }


### PR DESCRIPTION
Amélioration des marges entre les éléments du dropdown: moins de line-height, et plus d'espace entre les éléments pour qu'ils soient mieux séparés visuellement entre eux.

J'en ai profité pour augmenter un peu la largeur minimale des dropdowns, et pour corriger le positionnement du dropdown du dernier élément du breadcrumb.