### PR TITLE
Remove the usage of cdn.polyfill.io in the Styleguide Reader

### DIFF
--- a/reader/index.html
+++ b/reader/index.html
@@ -5,7 +5,6 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Styleguide</title>
-  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=String.prototype.includes,Array.prototype.includes,Array.prototype.find,CustomEvent"></script>
 
   <!-- Favicons -->
   <link rel="icon" type="image/png" sizes="228x228" href="./favicons/favicon-228.png">


### PR DESCRIPTION
`polyfill.io`, a popular JavaScript library service, can no longer be trusted and should be removed from websites.

It's currently used in the Styleguide Reader (https://epfl-si.github.io/elements/#/).

I propose to completely remove the third party library as every recent (and not so recent) browser natively support the feature requested.

More informations:
 * https://sansec.io/research/polyfill-supply-chain-attack
 * Drupal PSA: https://www.drupal.org/psa-2024-06-26