### PR TITLE
Number of typography weights

### DIFF
--- a/docs/design/typography.html
+++ b/docs/design/typography.html
@@ -2,7 +2,7 @@
   <h1 class="my-2">Typography</h1>
 
   <p class="mt-5">
-    Element use the <strong>Suisse Int'l</strong> (see <a href="https://www.epfl.ch/campus/services/communication/wp-content/uploads/2019/03/EPFL-brand-guidelines.pdf">Brand Guidelines</a>), has nine weights and is suitable for all uses, from titles to legends. If you do not have access or wish to use an authorized alternative, you must use Arial. On office materials, Arial is used exclusively, because it is available as a system font on all computers, making it easy to share editable documents.
+    Element use the <strong>Suisse Int'l</strong> (see <a href="https://www.epfl.ch/campus/services/communication/wp-content/uploads/2019/03/EPFL-brand-guidelines.pdf">Brand Guidelines</a>), has two weights and is suitable for all uses, from titles to legends. If you do not have access or wish to use an authorized alternative, you must use Arial. On office materials, Arial is used exclusively, because it is available as a system font on all computers, making it easy to share editable documents.
   </p>
 
   <div class="row my-5">


### PR DESCRIPTION
Suisse Int'l has just two weights:
- 400 (SuisseIntl-Regular-WebS)
- 700 (SuisseIntl-SemiBold-WebS)