### PR TITLE
Fix srcset dimension for Listing square Thumbnail

### DIFF
--- a/assets/components/atoms/picture/picture-thumb-square.twig
+++ b/assets/components/atoms/picture/picture-thumb-square.twig
@@ -2,7 +2,7 @@
 <picture>
   <source
     media="(min-width: 1140px)"
-    srcset="{{thumb_path}}95x95.jpg 1x, {{thumb_path}}240x240.jpg 2x">
+    srcset="{{thumb_path}}120x120.jpg 1x, {{thumb_path}}240x240.jpg 2x">
   <source
     media="(min-width: 960px)"
     srcset="{{thumb_path}}120x120.jpg 1x, {{thumb_path}}240x240.jpg 2x">


### PR DESCRIPTION
L'image `news_thumb-95x95.jpg` n'existe pas et les dimensions 2x ne sont pas raccord.
J'ai modifié les dimensions mais c'est peut-être pas l'idée initiale.