### PR TITLE
Remove code from Polyfill object-fit-images

### DIFF
--- a/assets/components/molecules/map/map.scss
+++ b/assets/components/molecules/map/map.scss
@@ -18,7 +18,6 @@
   img {
     height: 100%;
     object-fit: cover;
-    font-family: 'object-fit: cover;'; /* stylelint-disable-line */
   }
 }
 

--- a/assets/components/organisms/fullwidth-teaser/fullwidth-teaser.scss
+++ b/assets/components/organisms/fullwidth-teaser/fullwidth-teaser.scss
@@ -64,7 +64,6 @@
         left: 0;
         object-fit: cover;
         object-position: top center;
-        font-family: 'object-fit: cover;'; /* stylelint-disable-line */
         width: 100%;
         height: 100%;
         max-width: none;

--- a/assets/components/organisms/hero/hero.scss
+++ b/assets/components/organisms/hero/hero.scss
@@ -70,7 +70,6 @@
   img {
     object-fit: cover;
     object-position: center center;
-    font-family: 'object-fit: cover;'; /* stylelint-disable-line */
     width: 100%;
     height: 100%;
   }


### PR DESCRIPTION
It's useless since version 5 and the removal of the package.