### PR TITLE
Fix tagged breadcrumb preview

### DIFF
--- a/reader/reader.scss
+++ b/reader/reader.scss
@@ -45,6 +45,7 @@
     escape its container. */
 .tlbx-item-preview.tlbx-element-dropdown,
 .tlbx-item-preview.tlbx-element-select-multiple,
+.tlbx-item-preview.tlbx-element-breadcrumb-tagged,
 .tlbx-item-preview.tlbx-element-breadcrumb-dropdown {
   overflow: visible;
 }


### PR DESCRIPTION
https://epfl-si.github.io/elements/#/molecules/breadcrumb

Before:
<img width="1406" height="397" alt="1" src="https://github.com/user-attachments/assets/88fe7d7c-789d-4fa6-8ddc-c540fbb47a86" />

After:
<img width="1406" height="397" alt="2" src="https://github.com/user-attachments/assets/4ad17bc3-a237-419f-9ed8-fc36f39aa152" />
