### PR TITLE
Amélioration de l'accessibilité du header

### DIFF
--- a/assets/components/atoms/list/list.scss
+++ b/assets/components/atoms/list/list.scss
@@ -107,6 +107,7 @@ ol {
 .list-unstyled,
 .list-inline,
 .nav,
+.nav-lang,
 nav {
 
   li {

--- a/assets/components/atoms/nav-lang/nav-lang-short.twig
+++ b/assets/components/atoms/nav-lang/nav-lang-short.twig
@@ -1,6 +1,6 @@
 {% if language is not defined %}{% set language = 'fr' %}{% endif %}
 
-<nav class="nav-lang nav-lang-short ml-auto">
+<div class="nav-lang nav-lang-short ml-auto">
   <ul>
     {% if language == 'fr' %}
     <li>
@@ -27,4 +27,4 @@
       </li>
     {% endif %}
   </ul>
-</nav>
+</div>

--- a/assets/components/atoms/nav-lang/nav-lang.twig
+++ b/assets/components/atoms/nav-lang/nav-lang.twig
@@ -1,4 +1,4 @@
-<nav class="nav-lang ml-auto dropdown" aria-label="Change language">
+<div class="nav-lang ml-auto dropdown" aria-label="Change language">
   <button class="dropdown-toggle btn btn-secondary" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">
     {% include '@atoms/icon/icon.twig' with {icon: 'icon-planet'} %}
     <span>FR</span>
@@ -26,4 +26,4 @@
       </a>
     </li>
   </ul>
-</nav>
+</div>

--- a/assets/components/atoms/nav-toggle-mobile/nav-toggle-mobile.twig
+++ b/assets/components/atoms/nav-toggle-mobile/nav-toggle-mobile.twig
@@ -1,4 +1,4 @@
-<button class="btn btn-secondary nav-toggle-mobile d-xl-none">
+<button class="btn btn-secondary nav-toggle-mobile d-xl-none" aria-haspopup="true" aria-expanded="false" aria-controls="main-navigation">
   <span class="label">Menu</span>
   <div class="hamburger">
     <span></span>

--- a/assets/components/molecules/search/search-mobile.twig
+++ b/assets/components/molecules/search/search-mobile.twig
@@ -1,7 +1,7 @@
 {% if language is not defined %}{% set language = 'fr' %}{% endif %}
 
 <form action="#" class="d-xl-none">
-  <a id="search-mobile-toggle" class="search-mobile-toggle searchform-controller" href="#">
+  <button id="search-mobile-toggle" class="search-mobile-toggle searchform-controller" href="#">
     {% include '@atoms/icon/icon.twig' with { icon: 'icon-search' } %}
     {% if language == 'fr' %}
     <span class="toggle-label sr-only">Afficher / masquer le formulaire de recherche</span>
@@ -9,7 +9,7 @@
     {% if language == 'en' %}
     <span class="toggle-label sr-only">Show / hide the search form</span>
     {% endif %}
-  </a>
+  </button>
   <div class="input-group search-mobile" role="search">
     <div class="input-group-prepend">
       <span class="input-group-text">

--- a/assets/components/molecules/search/search-mobile.twig
+++ b/assets/components/molecules/search/search-mobile.twig
@@ -1,7 +1,7 @@
 {% if language is not defined %}{% set language = 'fr' %}{% endif %}
 
 <form action="#" class="d-xl-none">
-  <button id="search-mobile-toggle" class="search-mobile-toggle searchform-controller" href="#">
+  <button id="search-mobile-toggle" class="search-mobile-toggle searchform-controller">
     {% include '@atoms/icon/icon.twig' with { icon: 'icon-search' } %}
     {% if language == 'fr' %}
     <span class="toggle-label sr-only">Afficher / masquer le formulaire de recherche</span>

--- a/assets/components/molecules/search/search.scss
+++ b/assets/components/molecules/search/search.scss
@@ -5,6 +5,7 @@
 
   .dropdown-toggle {
     padding: $spacer;
+
     &:after {
       display: none;
     }
@@ -20,6 +21,19 @@
   input[type="text"] {
     width: 12rem;
     box-shadow: none !important;
+  }
+}
+
+.search button.dropdown-toggle,
+button.search-mobile-toggle {
+  background: transparent;
+  border: 0;
+  transition:
+    text-decoration-color 0.2s ease-in-out,
+    color 0.2s ease-in-out;
+
+  &:hover {
+    color: $red;
   }
 }
 

--- a/assets/components/molecules/search/search.twig
+++ b/assets/components/molecules/search/search.twig
@@ -1,9 +1,9 @@
 {% if language is not defined %}{% set language = 'fr' %}{% endif %}
 
 <div class="dropdown dropright search d-none d-xl-block">
-  <a class="dropdown-toggle" href="#" data-toggle="dropdown">
+  <button class="dropdown-toggle" href="#" data-toggle="dropdown">
     {% include "@atoms/icon/icon.twig" with { icon: 'icon-search' } %}
-  </a>
+  </button>
   <form action="#" class="dropdown-menu border-0 p-0">
     <div class="search-form mt-1 input-group">
       {% if language == 'fr' %}

--- a/assets/components/molecules/search/search.twig
+++ b/assets/components/molecules/search/search.twig
@@ -3,6 +3,12 @@
 <div class="dropdown dropright search d-none d-xl-block">
   <button class="dropdown-toggle" href="#" data-toggle="dropdown">
     {% include "@atoms/icon/icon.twig" with { icon: 'icon-search' } %}
+    {% if language == 'fr' %}
+    <span class="sr-only">Afficher le formulaire de recherche</span>
+    {% endif %}
+    {% if language == 'en' %}
+    <span class="sr-only">Show search form</span>
+    {% endif %}
   </button>
   <form action="#" class="dropdown-menu border-0 p-0">
     <div class="search-form mt-1 input-group">

--- a/assets/components/organisms/header/header.scss
+++ b/assets/components/organisms/header/header.scss
@@ -120,6 +120,16 @@
     .icon { font-size: 0.9em; }
   }
 
+  nav.navigation {
+    flex: 0 0 auto;
+    margin: 0 0 0 (3.7 * $spacer);
+
+    .nav-header {
+      flex: none;
+      margin: 0;
+    }
+  }
+
   @include media-breakpoint-down (lg) {
     height: $header-height;
     max-height: $header-height;

--- a/assets/components/organisms/header/header.twig
+++ b/assets/components/organisms/header/header.twig
@@ -6,21 +6,23 @@
   <a class="logo" href="#">
     <img src="svg/epfl-logo.svg" alt="Logo EPFL, École polytechnique fédérale de Lausanne" class="img-fluid">
   </a>
-  <ul class="nav-header d-none d-xl-flex">
-    {% for head in header %}
-      <li id="menu-item-{{ loop.index }}" {% if ( loop.index == 2 ) and ( showCurrentMenuItem|default(true) ) %} class="current-menu-item"{% endif %}>
-        {% if language == 'fr' %}
-        <a class="nav-item" href="{{ head.url_fr }}">{{ head.name_fr }}</a>
-        {% endif %}
-        {% if language == 'en' %}
-        <a class="nav-item" href="{{ head.url_en }}">{{ head.name_en }}</a>
-        {% endif %}
-        {% if language == 'de' %}
-          <a class="nav-item" href="{{ head.url_de }}">{{ head.name_de }}</a>
-        {% endif %}
-      </li>
-    {% endfor %}
-  </ul>
+  <nav class="navigation" role="navigation" aria-label="Menu principal">
+    <ul class="nav-header d-none d-xl-flex">
+      {% for head in header %}
+        <li id="menu-item-{{ loop.index }}" {% if ( loop.index == 2 ) and ( showCurrentMenuItem|default(true) ) %} class="current-menu-item"{% endif %}>
+          {% if language == 'fr' %}
+          <a class="nav-item" href="{{ head.url_fr }}">{{ head.name_fr }}</a>
+          {% endif %}
+          {% if language == 'en' %}
+          <a class="nav-item" href="{{ head.url_en }}">{{ head.name_en }}</a>
+          {% endif %}
+          {% if language == 'de' %}
+            <a class="nav-item" href="{{ head.url_de }}">{{ head.name_de }}</a>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </nav>
   {% include '@molecules/search/search.twig' %}
   {% include '@molecules/search/search-mobile.twig' %}
   {%  if nav_user %}

--- a/assets/components/organisms/header/header.twig
+++ b/assets/components/organisms/header/header.twig
@@ -6,7 +6,7 @@
   <a class="logo" href="#">
     <img src="svg/epfl-logo.svg" alt="Logo EPFL, École polytechnique fédérale de Lausanne" class="img-fluid">
   </a>
-  <ul aria-hidden="true" class="nav-header d-none d-xl-flex">
+  <ul class="nav-header d-none d-xl-flex">
     {% for head in header %}
       <li id="menu-item-{{ loop.index }}" {% if ( loop.index == 2 ) and ( showCurrentMenuItem|default(true) ) %} class="current-menu-item"{% endif %}>
         {% if language == 'fr' %}

--- a/assets/components/organisms/nav-main/nav-main.js
+++ b/assets/components/organisms/nav-main/nav-main.js
@@ -15,6 +15,11 @@ const nav = () => {
     }
 
     $('body').toggleClass('mobile-menu-open');
+
+    // update aria-expanded attribute
+    $('.nav-toggle-mobile').attr('aria-expanded',
+      $('.nav-toggle-mobile').attr('aria-expanded') == 'false' ? 'true' : 'false'
+    );
   };
 
   // Open or close desktop toggle navigation, keeping its actual position.


### PR DESCRIPTION
- Suppression de l'attribut `aria-hidden="true"` sur l'élément `.nav-header`, qui masquait l’ensemble du menu de navigation principale pour les lecteurs d'écran utilisés par les personnes aveugles ou malvoyantes.
- Ajout d'une balise `<nav>` autour du menu principal.
- En revanche le sélecteur de langue doit être dans un `<div>`, pas dans un `<nav>`.
- Utilisation d'une balise `<button>` plutôt que `<a>` pour le bouton qui sert à afficher le champ de recherche, et ajout d'un nom accessible masqué.

https://epfl-webvolution.atlassian.net/browse/WEBEVOL-225