### PR TITLE
EPFL Caption Cards' / Schools' title size

### DIFF
--- a/assets/components/content-types/school/school.scss
+++ b/assets/components/content-types/school/school.scss
@@ -1,1 +1,9 @@
 @charset 'utf-8';
+
+.card {
+  .h4 {
+    @include media-breakpoint-down(xl) {
+      font-size: 1.152rem;
+    }
+  }
+}


### PR DESCRIPTION
- Adjusting the size of EPFL Caption Cards titles for screen widths smaller than 1200px

https://epfl-webvolution.atlassian.net/browse/WEBEVOL-270