### PR TITLE
WP Scheduler width

### DIFF
--- a/assets/components/site.scss
+++ b/assets/components/site.scss
@@ -113,3 +113,8 @@ body {
     margin-top: 0.625em;
   }
 }
+
+.wp-block-epfl-scheduler {
+  grid-column: full;
+}
+


### PR DESCRIPTION
- set EPFL WP Scheduler width to container-full