### PR TITLE
External links with icon

### DIFF
--- a/assets/components/atoms/link/link-external.twig
+++ b/assets/components/atoms/link/link-external.twig
@@ -1,0 +1,4 @@
+<a href="#" rel="nofollow" target="_blank">
+  Link with an external link icon
+  {% include '@atoms/icon/icon.twig' with {'icon': 'external-link'} %}
+</a>

--- a/assets/components/atoms/link/link.yml
+++ b/assets/components/atoms/link/link.yml
@@ -18,6 +18,10 @@ variants:
   - name: bg-variants
     title: Background variants
     notes:
+  - name: external
+    title: External website
+    notes: |
+      Add `rel="nofollow"` and `target="_blank"` attributes to ensure links open in a new tab or window.
   - name: icon
     title: Icon
     notes: |


### PR DESCRIPTION
Add #external-link icon if the link points to a website outside the EPFL domain.