### PR TITLE
Add custom loader to Selectize.js

### DIFF
--- a/assets/components/atoms/tag/tag.scss
+++ b/assets/components/atoms/tag/tag.scss
@@ -243,4 +243,22 @@ button.tag {
       }
     }
   }
+
+  &.loading .selectize-input {
+    position: relative;
+
+    &:after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      right: $input-padding-x;
+      width: 1.1rem;
+      height: 1.1rem;
+      margin-top: -0.55rem;
+      border: 3px solid gray('200');
+      border-right-color: gray('600');
+      border-radius: 100%;
+      animation: rotation 1s linear infinite;
+    }
+  }
 }


### PR DESCRIPTION
Ajout d'un indicateur de chargement à partir du composant loader pour les appels externes avec Selectize.js.
La classe `loading` est ajoutée automatiquement par Selectize.js avec la fonction `load`.

<img width="588" height="298" alt="Screenshot from 2026-07-31 11-08-50" src="https://github.com/user-attachments/assets/f9411b85-bfb7-4586-9210-647c9c288e98" />
